### PR TITLE
Updating links to be consistent with the repository rebranding

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Website generation
 
-[This repo's website](https://atcold.github.io/pytorch-Deep-Learning-Minicourse/) is automatically served via [GitHub Pages](https://pages.github.com/) using [Jekyll](https://jekyllrb.com/).
+[This repo's website](https://atcold.github.io/pytorch-Deep-Learning) is automatically served via [GitHub Pages](https://pages.github.com/) using [Jekyll](https://jekyllrb.com/).
 
 # Running locally
 

--- a/docs/chapters/01-3.md
+++ b/docs/chapters/01-3.md
@@ -46,7 +46,7 @@ The first matrix maps the two dimensional input to a 100 dimensional intermediat
 
 ## [Random Projections - Jupyter Notebook](0:33:19 - 0:54:25)
 
-The jupyter notebook can be found [here](https://github.com/Atcold/pytorch-Deep-Learning-Minicourse/blob/master/02-space_stretching.ipynb). In order to run the notebook, make sure you have the `dl-minicourse` environment installed as specified in [`README.md`](https://github.com/Atcold/pytorch-Deep-Learning-Minicourse/blob/master/README.md).
+The jupyter notebook can be found [here](https://github.com/Atcold/pytorch-Deep-Learning/blob/master/02-space_stretching.ipynb). In order to run the notebook, make sure you have the `pDL` environment installed as specified in [`README.md`](https://github.com/Atcold/pytorch-Deep-Learning/blob/master/README.md).
 
 
 ### PyTorch Device

--- a/docs/chapters/02-3.md
+++ b/docs/chapters/02-3.md
@@ -234,9 +234,9 @@ $$ \frac{\partial \, J(\mathcal{\Theta})}{\partial \, \boldsymbol{W_y}} = \frac{
 
 ## [Spiral Classification - Jupyter notebook](42:00)
 
-The Jupyter notebook can be found [here](https://github.com/Atcold/pytorch-Deep-Learning-Minicourse/blob/master/04-spiral_classification.ipynb). In order to run the notebook, make sure you have `the dl-minicourse` environment installed as specified in [README.md](https://github.com/Atcold/pytorch-Deep-Learning-Minicourse/blob/master/README.md).
+The Jupyter notebook can be found [here](https://github.com/Atcold/pytorch-Deep-Learning/blob/master/04-spiral_classification.ipynb). In order to run the notebook, make sure you have the `pDL` environment installed as specified in [README.md](https://github.com/Atcold/pytorch-Deep-Learning/blob/master/README.md).
 
-An explanation of how to use `torch.device()` can be found in [last week's notes](https://atcold.github.io/pytorch-Deep-Learning-Minicourse/chapters/01-3/).
+An explanation of how to use `torch.device()` can be found in [last week's notes](https://atcold.github.io/pytorch-Deep-Learning/chapters/01-3/).
 
 Like before, we are going to be working with points in $\mathbb{R}^2$ with three different categorical labels - in red, yellow and blue - as can be seen in **Fig. 8**.
 
@@ -263,7 +263,7 @@ When we go from a linear model to one with two `nn.linear()` modules and a `nn.R
     <b>Fig. 10</b> Non-linear decision boundaries.
 </center>
 
-An example of a regression problem which can't be solved correctly with a linear regression, but is easily solved with the same neural network structure can be seen in [this notebook](https://github.com/Atcold/pytorch-Deep-Learning-Minicourse/blob/master/05-regression.ipynb) and **Fig. 11**, which shows 10 different networks, where 5 have a a `nn.ReLU()` link function and 5 have a `nn.Tanh()`. The former is a piecewise linear function, where the latter is a continuous and smooth regression.
+An example of a regression problem which can't be solved correctly with a linear regression, but is easily solved with the same neural network structure can be seen in [this notebook](https://github.com/Atcold/pytorch-Deep-Learning/blob/master/05-regression.ipynb) and **Fig. 11**, which shows 10 different networks, where 5 have a a `nn.ReLU()` link function and 5 have a `nn.Tanh()`. The former is a piecewise linear function, where the latter is a continuous and smooth regression.
 
 <center>
 <img src="5-nn-reg.png" style="zoom: 64%; background-color:#DCDCDC;" /><br>

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ title: DEEP LEARNING
 | LECTURES    | Mondays 16:55 – 18:35, [GCASL C95](http://library.nyu.edu/services/campus-media/classrooms/gcasl-c95/) |
 | PRACTICA    | Tuesdays 19:10 – 20:00, [GCASL C95](http://library.nyu.edu/services/campus-media/classrooms/gcasl-c95/) |
 | [PIAZZA](https://piazza.com/nyu/spring2020/dsga1008/home)      | Access code: `DLSP20` |
-| MATERIAL    | [Google Drive](https://bitly.com/DLSP20), [Notebooks](https://github.com/Atcold/pytorch-Deep-Learning-Minicourse) |
+| MATERIAL    | [Google Drive](https://bitly.com/DLSP20), [Notebooks](https://github.com/Atcold/pytorch-Deep-Learning) |
 
 
 ## Description
@@ -45,8 +45,8 @@ This course concerns the latest techniques in deep learning and representation l
       <td rowspan="1">Practicum</td>
       <td><a href="chapters/01-3">Neural nets (NN)</a></td>
       <td>
-        <a href="https://github.com/Atcold/pytorch-Deep-Learning-Minicourse/blob/master/01-tensor_tutorial.ipynb">📓</a>
-        <a href="https://github.com/Atcold/pytorch-Deep-Learning-Minicourse/blob/master/02-space_stretching.ipynb">📓</a>
+        <a href="https://github.com/Atcold/pytorch-Deep-Learning/blob/master/01-tensor_tutorial.ipynb">📓</a>
+        <a href="https://github.com/Atcold/pytorch-Deep-Learning/blob/master/02-space_stretching.ipynb">📓</a>
       </td>
     </tr>
 <!-- =============================== WEEK 2 ================================ -->
@@ -63,9 +63,9 @@ This course concerns the latest techniques in deep learning and representation l
       <td rowspan="1">Practicum</td>
       <td><a href="chapters/02-3">NN training</a></td>
       <td>
-        <a href="https://github.com/Atcold/pytorch-Deep-Learning-Minicourse/blob/master/slides/01%20-%20Spiral%20classification.pdf">🖥</a>
-        <a href="https://github.com/Atcold/pytorch-Deep-Learning-Minicourse/blob/master/04-spiral_classification.ipynb">📓</a>
-        <a href="https://github.com/Atcold/pytorch-Deep-Learning-Minicourse/blob/master/05-regression.ipynb">📓</a>
+        <a href="https://github.com/Atcold/pytorch-Deep-Learning/blob/master/slides/01%20-%20Spiral%20classification.pdf">🖥</a>
+        <a href="https://github.com/Atcold/pytorch-Deep-Learning/blob/master/04-spiral_classification.ipynb">📓</a>
+        <a href="https://github.com/Atcold/pytorch-Deep-Learning/blob/master/05-regression.ipynb">📓</a>
       </td>
     </tr>
 <!-- =============================== WEEK 3 ================================ -->
@@ -82,8 +82,8 @@ This course concerns the latest techniques in deep learning and representation l
       <td rowspan="1">Practicum</td>
       <td><a href="chapters/03-3"></a>–</td>
       <td>
-        <a href="https://github.com/Atcold/pytorch-Deep-Learning-Minicourse/blob/master/slides/02%20-%20CNN.pdf">🖥</a>
-        <a href="https://github.com/Atcold/pytorch-Deep-Learning-Minicourse/blob/master/06-convnet.ipynb">📓</a>
+        <a href="https://github.com/Atcold/pytorch-Deep-Learning/blob/master/slides/02%20-%20CNN.pdf">🖥</a>
+        <a href="https://github.com/Atcold/pytorch-Deep-Learning/blob/master/06-convnet.ipynb">📓</a>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Some of the old links were working fine (the ones that directly pointed to a resource in the repository).

Some were not (the ones that pointed to the course website).

Updated all (hopefully!) to point to the new repository/site.