### PR TITLE
Fix chapter 5-2 docs

### DIFF
--- a/docs/chapters/05-2.md
+++ b/docs/chapters/05-2.md
@@ -21,7 +21,7 @@ Networks that are often used in practice have different structure in different p
 Weights in the latter part of the network (4096 in figure 1 below) directly dictate the output and have a very strong effect on it. Hence, we need smaller learning rates for those. In contrast, earlier weights will have smaller individual effects on the output, especially when initialized randomly.
 
 <center>
-<img src="5_2_vgg.png" style="zoom:40%"></br>
+<img src="5_2_vgg.png" style="zoom:40%"><br>
 <b>Figure 1: </b>VGG16
 </center>
 
@@ -70,9 +70,9 @@ Bias correction that is used to keep the moving average unbiased during early it
 When training neural networks, SGD often goes in the wrong direction in the beginning of the training process, whereas RMSprop hones in on the right direction. However, RMSprop suffers from noise just as regular SGD, so it bounces around the optimum significantly once it's close to a local minimizer. Just like when we add momentum to SGD, we get the same kind of improvement with ADAM. It is a good, not-noisy estimate of the solution, so **ADAM is generally recommended over RMSprop**.
 
 <center>
-<img src="5_2_comparison.png" style="zoom:45%"></br>
+<img src="5_2_comparison.png" style="zoom:45%"><br>
 <b>Figure 2: </b> SGD vs RMSprop vs ADAM
-</center></br>
+</center><br>
 
 ADAM is necessary for training some of the networks for using language models. For optimizing neural networks, SGD with momentum or ADAM is generally preferred. However, ADAM's theory in papers is poorly understood and it also has several disadvantages:
 
@@ -88,7 +88,7 @@ Rather than improving the optimization algorithms, *normalization layers* improv
 
 In neural networks, we typically alternate linear operations with non-linear operations. The non-linear operations are also known as activation functions, such as ReLU. We can place normalization layers before the linear layers, or after the activation functions. The most common practice is to put them between the linear layers and activation functions, as in the figure below.
 
-| <center><img src="5_2_norm_layer_a.png"5_2_ width="200px"/></center> | <center><img src="norm_layer_b.png"5_2_ width="200px"/></center> | <center><img src="norm_layer_c.png" width="200px"/></center> |
+| <center><img src="5_2_norm_layer_a.png" width="200px"/></center> | <center><img src="5_2_norm_layer_b.png" width="200px"/></center> | <center><img src="5_2_norm_layer_c.png" width="200px"/></center> |
 | (a) Before adding normalization                              |                (b) After adding normalization                |                    (c) An example in CNNs                    |
 
 <center><b>Figure 3:</b> Typical positions of normalization layers.</center>
@@ -155,7 +155,7 @@ Note that for batch norm and instance norm, the mean/std used are fixed after tr
 Sometimes we can barge into a field we know nothing about and improve how they are currently implementing things. One such example is the use of deep neural networks in the field of Magnetic Resonance Imaging (MRI) to accelerate MRI image reconstruction.
 
 <center>
-<img src="5_2_conv_xkcd.png" style="zoom:60%"></br>
+<img src="5_2_conv_xkcd.png" style="zoom:60%"><br>
 <b>Figure 5: </b>Sometimes it actually works!
 </center>
 
@@ -167,7 +167,7 @@ In the traditional MRI reconstruction problem, raw data is taken from an MRI mac
 <center>
 <img src="5_2_mri.png" style="zoom:60%"/><br>
 <b>Figure 6: </b>MRI reconstruction
-</center></br>
+</center><br>
 
 A linear mapping currently exists to go from the Fourier domain to the image domain and it's very efficient, literally taking milliseconds, no matter how big the image is. But the question is, can we do it even faster?
 
@@ -179,7 +179,7 @@ The new problem that needs to be solved is accelerated MRI, where by acceleratio
 <center>
 <img src="5_2_acc_mri.png" style="zoom:45%"></br>
 <b>Figure 7: </b>Linear mapping on subsampled Fourier-space
-</center></br>
+</center><br>
 
 
 ### Compressed Sensing
@@ -191,7 +191,7 @@ Another condition is that we need to have *sparsity* in our image, where by spar
 <center>
 <img src="5_2_comp_sensing.png" style="zoom:50%"></br>
 <b>Figure 8: </b>Compressed sensing
-</center></br>
+</center><br>
 
 Compressed sensing is based on the theory of optimization. The way we can get this reconstruction is by solving a mini-optimization problem which has an additional regularization term:
 
@@ -217,8 +217,8 @@ where $B$ is our deep learning model and $y$ is the observed Fourier-domain data
 15 years ago, this approach was difficult - but nowadays this is a lot easier to implement. Figure 9 shows the result of a deep learning approach to this problem and we can see that the output is much better than the compressed sensing approach and looks very similar to the actual scan.
 
 <center>
-<img src="5_2_dl_approach.png" style="zoom:60%"></br>
+<img src="5_2_dl_approach.png" style="zoom:60%"><br>
 <b>Figure 9: </b>Deep Learning approach
-</center></br>
+</center><br>
 
 The model used to generate this reconstruction uses an ADAM optimizer, group-norm normalization layers, and a U-Net based convolutional neural network. Such an approach is very close to practical applications and we will hopefully be seeing these accelerated MRI scans happening in clinical practice in a few years' time.

--- a/docs/chapters/05-2.md
+++ b/docs/chapters/05-2.md
@@ -174,7 +174,7 @@ A linear mapping currently exists to go from the Fourier domain to the image dom
 The new problem that needs to be solved is accelerated MRI, where by acceleration we mean making the MRI reconstruction process much faster. We want to run the machines quicker and still be able to produce identical quality images. One way we can do this and the most successful way so far has been to not capture all the columns from the MRI scan. We can skip some columns randomly, though it's useful in practice to capture the middle columns, as they contain a lot of information across the image, but outside them we just capture randomly. The problem is that we can't use our linear mapping anymore to reconstruct the image. The rightmost image in Figure 7 shows the output of a linear mapping applied to the subsampled Fourier space. It's clear that this method doesn't give us very useful outputs, and that there's room to do something a little bit more intelligent.
 
 <center>
-<img src="5_2_acc_mri.png" style="zoom:45%"></br>
+<img src="5_2_acc_mri.png" style="zoom:45%"><br>
 <b>Figure 7: </b>Linear mapping on subsampled Fourier-space
 </center><br>
 
@@ -186,7 +186,7 @@ One of the biggest breakthroughs in theoretical mathematics for a long time was 
 Another condition is that we need to have *sparsity* in our image, where by sparsity we mean a lot of zeros or black pixels in the image. The raw input can be represented sparsely if we do a wavelength decomposition, but even this decomposition gives us an approximately sparse and not an exactly sparse image. So, this approach gives us a pretty good but not perfect reconstruction, as we can see in Figure 8. However, if the input were very sparse in the wavelength domain, then we would definitely get a perfect image.
 
 <center>
-<img src="5_2_comp_sensing.png" style="zoom:50%"></br>
+<img src="5_2_comp_sensing.png" style="zoom:50%"><br>
 <b>Figure 8: </b>Compressed sensing
 </center><br>
 

--- a/docs/chapters/05-2.md
+++ b/docs/chapters/05-2.md
@@ -85,7 +85,7 @@ Rather than improving the optimization algorithms, *normalization layers* improv
 
 In neural networks, we typically alternate linear operations with non-linear operations. The non-linear operations are also known as activation functions, such as ReLU. We can place normalization layers before the linear layers, or after the activation functions. The most common practice is to put them between the linear layers and activation functions, as in the figure below.
 
-| <center><img src="5_2_norm_layer_a.png" width="200px"/></center> | <center><img src="5_2_norm_layer_b.png" width="200px"/></center> | <center><img src="5_2_norm_layer_c.png" width="200px"/></center> |
+| <center><img src="5_2_norm_layer_a.png" width="200px"/></center> | <center><img src="5_2_norm_layer_b.png" width="200px"/></center> | <center><img src="5_2_norm_layer_c.png" width="225px"/></center> |
 | (a) Before adding normalization                              |                (b) After adding normalization                |                    (c) An example in CNNs                    |
 
 <center><b>Figure 3:</b> Typical positions of normalization layers.</center>

--- a/docs/chapters/05-2.md
+++ b/docs/chapters/05-2.md
@@ -7,9 +7,6 @@ typora-root-url: 05-3
 ---
 
 
-# Optimization Techniques II
-
-
 ## Adaptive Methods
 
 SGD with momentum is currently the state of the art optimization method for a lot of ML problems. But there are other methods, generally called Adaptive Methods, innovated over the years that are particularly useful for poorly conditioned problems (if SGD does not work).


### PR DESCRIPTION
As discussed, the fixes to not break the website and make it look terrible. The one noteworthy thing I want to comment on is that image 3c was having some CSS issues where despite having `width=200px` **and the exact same image size as the other two images**, it would display at ~181px width. I changed the width accordingly to make it consistent with the others.

I've tested out the website locally and it looks fine now, but let me know if I missed anything. Thanks for your patience!