### PR TITLE
Update 04-1.md

### DIFF
--- a/docs/chapters/04-1.md
+++ b/docs/chapters/04-1.md
@@ -23,17 +23,19 @@ $$
 For simplicity bias are ignored. The linear equation can be expanded as:
 
 $$
-\begin {aligned}
-\boldsymbol{z} &= A \boldsymbol{x} \ =\left[\begin{matrix}
-a_{11} & a_{11} & \cdots & a_{1n}\\
-a_{21} & a_{22} & \cdots & a_{2n} \\
-\vdots & \vdots & \ddots & \vdots \\
-a_{m1} & a_{m2} & \cdots & a_{mn} \end{matrix} \right] \left[\begin{matrix}
-x_1 \\ x_2\\\vdots \\x_n \end{matrix} \right]
-=\left[\begin{matrix}
-a^{(1)}\boldsymbol{x} \\a^{(2)}\boldsymbol{x}\\\vdots \\
-a^{(m)}\boldsymbol{x}\end{matrix} \right] =\boldsymbol{z}
-\end {aligned}
+\boldsymbol{z} = A\boldsymbol{x} =
+\begin{bmatrix}
+    - \; {\boldsymbol{a}}^{(1)} \; - \\
+    - \; {\boldsymbol{a}}^{(2)} \; - \\
+    \vdots \\
+    - \; {\boldsymbol{a}}^{(m)} \; - \\
+\end{bmatrix}
+\begin{pmatrix}
+    \rvert \\ \boldsymbol{x} \\ \rvert
+\end{pmatrix} =
+\begin{pmatrix}
+    {\boldsymbol{a}}^{(1)} \boldsymbol{x} \\ {\boldsymbol{a}}^{(2)} \boldsymbol{x} \\ \vdots \\ {\boldsymbol{a}}^{(m)} \boldsymbol{x}
+\end{pmatrix}_{m \times 1}
 $$
 
 where $\boldsymbol{a}^{(i)}$ is the $i$-th row of the matrix $\boldsymbol{A}$.
@@ -53,29 +55,16 @@ The output measures the alignment of the input to specific row of the matrix $A$
 Another way to understand the linear transformation, $\boldsymbol{z}$ can also be expanded as:
 
 $$
-a^\top\boldsymbol{x}=
-\left[
-\begin{matrix}
-a_{11} \\
-a_{21}\\
-\vdots \\
-a_{m1}
-\end{matrix}
-\right]x_1+\left[
-\begin{matrix}
-a_{12} \\
-a_{22}\\
-\vdots \\
-a_{m2}
-\end{matrix}
-\right]x_2 + ...... +\left[
-\begin{matrix}
-a_{1n} \\
-a_{2n}\\
-\vdots \\
-a_{mn}
-\end{matrix}
-\right]x_n
+z = \begin{bmatrix} z_1 \\ z_2 \\ \cdots \\z_m\end{bmatrix} = \begin{pmatrix}
+    {\boldsymbol{a}}^{(1)} \boldsymbol{x} \\ {\boldsymbol{a}}^{(2)} \boldsymbol{x} \\ \vdots \\ {\boldsymbol{a}}^{(m)} \boldsymbol{x}
+\end{pmatrix}
+= \begin{pmatrix}
+    \rvert \\ \boldsymbol{a}^{(1)} \\ \rvert
+\end{pmatrix} \boldsymbol{x_1} + \begin{pmatrix}
+    \rvert \\ \boldsymbol{a}^{(2)} \\ \rvert
+\end{pmatrix} \boldsymbol{x_2}+\cdots+\begin{pmatrix}
+    \rvert \\ \boldsymbol{a}^{(n)} \\ \rvert
+\end{pmatrix} \boldsymbol{x_n}
 $$
 
 The output is the weighted sum of the columns of the $A$ matrix. So the signal is nothing but a composition of the input.


### PR DESCRIPTION
changed matrix notation to
```
                 |
----a^(j)----   a_i
                 |
```
as discussed