### PR TITLE
Fix bug with images displaying on the website

### DIFF
--- a/docs/en/about.md
+++ b/docs/en/about.md
@@ -18,12 +18,13 @@ When adding figures, make sure they are centred in the page. To do this, follow 
 
 ```html
 <center>
-<img src="/images/week01/01-3/Network.png" style="zoom: 40%; background-color:#DCDCDC;" /><br>
+<img src="{% link /images/week01/01-3/Network.png %}" style="zoom: 40%; background-color:#DCDCDC;" /><br>
 <b>Figure 2:</b> Network architecture.
 </center>
 ```
 
 In this particular example, the author chose to resize the image to 40% of its original size. Given that the image had a transparent background, an additional light colour (`#DCDCDC`) has been added to the background.
+Note that you _must_ use the liquid tag `link` in order for images to link properly. This should be done for all text-based links as well.
 
 
 ## Adding figures side by side
@@ -31,7 +32,7 @@ In this particular example, the author chose to resize the image to 40% of its o
 In this case the author displayed two figures, side by side, using a table.
 
 ```html
-| <center><img src="/images/week01/01-3/Spiral1.png" width="200px"/></center> | <center><img src="/images/week01/01-3/Spiral2.png" height="170px"/></center> |
+| <center><img src="{% link /images/week01/01-3/Spiral1.png %}" width="200px"/></center> | <center><img src="{% link /images/week01/01-3/Spiral2.png %}" height="170px"/></center> |
 |            (a) Input points, pre-network                |           (b) Output points, post-network                |
 
 <center><b>Figure 1:</b> Five color spiral.</center>

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -122,7 +122,7 @@ This course concerns the latest techniques in deep learning and representation l
 
 | Role | Photo | Contact | About |
 |:-----|:-----:|:--------|:------|
-|Instructor|<img src="/images/index/Yann.png" width="100" height="100">|<a href="https://twitter.com/ylecun">Yann LeCuna</a><br>yann@cs.nyu.edu|Silver Professor in CS at NYU<br>and Turing Award winner|
+|Instructor|<img src="{% link /images/index/Yann.png %}" width="100" height="100">|<a href="https://twitter.com/ylecun">Yann LeCuna</a><br>yann@cs.nyu.edu|Silver Professor in CS at NYU<br>and Turing Award winner|
 |Instructor|<img src="https://pbs.twimg.com/profile_images/1204441318207950855/qEPqQ01h_400x400.jpg" width="100" height="100">|<a href="https://twitter.com/alfcnz">Alfredo Canziani</a><br>canziani@nyu.edu|Asst. Prof. in CS at NYU|
 |Assistant|<img src="https://pbs.twimg.com/profile_images/1186879808845860864/czRv3g1G_400x400.jpg" width="100" height="100">|<a href="https://twitter.com/marikgoldstein">Mark Goldstein</a><br>goldstein@nyu.edu|PhD student in CS at NYU|
 |Webmaster|<img src="https://pbs.twimg.com/profile_images/673997980370927616/vMXf545j_400x400.jpg" width="100" height="100">|<a href="https://twitter.com/ebetica">Zeming Lin</a><br>zl2799@nyu.edu|PhD student in CS at NYU|

--- a/docs/en/week01/01-3.md
+++ b/docs/en/week01/01-3.md
@@ -28,7 +28,7 @@ Note that translation alone is not linear since 0 will not always be mapped to 0
 
 In our visualization, we have five branches of a spiral, with each branch corresponding to a different colour. The points live in a two dimensional plane and can be represented as a tuple; the colour represents a third dimension which can be thought of as the different classes for each of the points. We then use the network to separate each of the points by colour.
 
-| <center><img src="/images/week01/01-3/Spiral1.png" width="200px"/></center> | <center><img src="/images/week01/01-3/Spiral2.png" width="200px"/></center> |
+| <center><img src="{% link /images/week01/01-3/Spiral1.png %}" width="200px"/></center> | <center><img src="{% link /images/week01/01-3/Spiral2.png %}" width="200px"/></center> |
 |             (a) Input points, pre-network             |            (b) Output points, post-network             |
 
 <center> Figure 1: Five colour spiral </center>
@@ -38,7 +38,7 @@ They network \"stretches\" the space fabric in order to separate each of the poi
 ### Network architecture
 
 <center>
-<img src="/images/week01/01-3/Network.png" style="zoom: 40%; background-color:#DCDCDC;" /><br>
+<img src="{% link /images/week01/01-3/Network.png %}" style="zoom: 40%; background-color:#DCDCDC;" /><br>
 Figure 2: Network Architecture
 </center>
 
@@ -81,7 +81,7 @@ We visualize the linear transformations of several random matrices in Fig. 3. No
 
 The matrices used were generated with Numpy; however, we can also use PyTorch's `nn.Linear` class with `bias = False` to create linear transformations.
 
-| ![](/images/week01/01-3/initial_scatter_lab1.png) | ![](/images/week01/01-3/matrix_multiplication_lab1.png) | ![](/images/week01/01-3/matrix_multiplication_lab1_2.png) |
+| ![]({% link /images/week01/01-3/initial_scatter_lab1.png %}) | ![]({% link /images/week01/01-3/matrix_multiplication_lab1.png %}) | ![]({% link /images/week01/01-3/matrix_multiplication_lab1_2.png %}) |
 |     (a) Original points       |   (b) $s_1$ = 1.540, $s_2$ = 0.304  |   (c) $s_1$ = 0.464, $s_2$ = 0.017    |
 
 <center> Figure 3:  Linear transformations from random matrices </center>
@@ -98,13 +98,13 @@ $$
 Recall, the graph of $\tanh(\cdot)$ in Fig. 4.
 
 <center>
-<img src="/images/week01/01-3/tanh_lab1.png" width="250px" /><br>
+<img src="{% link /images/week01/01-3/tanh_lab1.png %}" width="250px" /><br>
 Figure 4: hyperbolic tangent non-linearity
 </center>
 
 The effect of this non-linearity is to bound points between $-1$ and $+1$, creating a square. As the value of $s$ in eq. (2) increases, more and more points are pushed to the edge of the square. This is shown in Fig. 5. By forcing more points to the edge, we spread them out more and can then attempt to classify them.
 
-| <img src="/images/week01/01-3/matrix_multiplication_with_nonlinearity_s=1_lab1.png" width="200px" /> | <img src="/images/week01/01-3/matrix_multiplication_with_nonlinearity_s=5_lab1.png" width="200px" /> |
+| <img src="{% link /images/week01/01-3/matrix_multiplication_with_nonlinearity_s=1_lab1.png %}" width="200px" /> | <img src="{% link /images/week01/01-3/matrix_multiplication_with_nonlinearity_s=5_lab1.png %}" width="200px" /> |
 |                 (a) Non-linearity with $s=1$                 |                 (b) Nonlinearity with $s=5$                  |
 
 <center> Figure 5:   Non-linear Transformations </center>
@@ -115,6 +115,6 @@ The effect of this non-linearity is to bound points between $-1$ and $+1$, creat
 Lastly, we visualize the transformation performed by a simple, untrained neural network. The network consists of a linear layer, which performs an affine transformation, followed by a hyperbolic tangent non-linearity, and finally another linear layer. Examining the transformation in Fig. 6, we see that it is unlike the linear and non-linear transformations seen earlier. Going forward, we will see how to make these transformations performed by neural networks useful for our end goal of classification.
 
 <center>
-<img src="/images/week01/01-3/untrained_nn_transformation_lab1.png" width="200px" /><br>
+<img src="{% link /images/week01/01-3/untrained_nn_transformation_lab1.png %}" width="200px" /><br>
 Figure 6:  Transformation from an untrained neural network
 </center>

--- a/docs/en/week02/02-1.md
+++ b/docs/en/week02/02-1.md
@@ -73,7 +73,7 @@ $$
 
 ​	Average Loss over the Set S is given by :  $$L(S,w) = \frac{1}{P} \sum_{(x,y)} L(x,y,w)$$
 
-| <center><img src="/images/week02/02-1/Average_Loss.png" alt="Average_Loss" style="zoom:33%;" /></center> |
+| <center><img src="{% link /images/week02/02-1/Average_Loss.png %}" alt="Average_Loss" style="zoom:33%;" /></center> |
 |   Figure 2. Computation graph for model with Average Loss    |
 
 In the standard Supervised Learning paradigm, the loss (per sample) is simply the output of the cost function. Machine Learning is mostly about optimizing functions (usually minimizing them). It could also involve finding Nash Equilibria between two functions like with GANs. This is done using Gradient Based Methods, though not necessarily Gradient Descent.
@@ -128,7 +128,7 @@ In the formula, $w$ is approached by $w$ minus the step-size, times the gradient
 
 If we do this on a single sample, we will get a very noisy trajectory as shown in Figure 3. Instead of the loss going directly downhill, it’s stochastic. Every sample will pull the loss towards a different direction. It’s just the average that pulls us to the minimum of the average. Although it looks inefficient, it’s much faster than batch gradient descent at least in the context of machine learning when the samples have some redundancy.
 
-| <center><img src="/images/week02/02-1/Figure2.png" alt="Figure2" style="zoom:80%;" /></center> |
+| <center><img src="{% link /images/week02/02-1/Figure2.png %}" alt="Figure2" style="zoom:80%;" /></center> |
 | Figure 3: Stochastic Gradient Descent trajectory for per sample update |
 
 
@@ -139,14 +139,14 @@ In practice, we use batches instead of doing stochastic gradient descent on a si
 
 Traditional Neural Nets are basically interspersed layers of linear operations and point-wise non-linear operations. For linear operations, conceptually it is just a matrix-vector multiplication. We take the (input) vector multiplied by a matrix formed by the weights. The second type of operation is to take all the components of the weighted sums vector and pass it through some simple non-linearity (i.e. $\texttt{ReLU}(\cdot)$, $\tanh(\cdot)$, …).
 
-| <center><img src="/images/week02/02-1/Figure3.png" alt="Figure3" style="zoom:30%;" /></center> |
+| <center><img src="{% link /images/week02/02-1/Figure3.png %}" alt="Figure3" style="zoom:30%;" /></center> |
 |             Figure 4: Traditional Neural Network             |
 
 Figure 4 is an example of a 2-layer network, because what matters are the pairs (i.e linear+non-linear). Some people call it a 3-layer network because they count the variables. Note that if there are no non-linearities in the middle, we may as well have a single layer because the product of two linear functions is a linear function.
 
 Figure 5 shows how the linear and non-linear functional blocks of the network stack:
 
-| <center><img src="/images/week02/02-1/Figure4.png" alt="Figure4" style="zoom:30%;" /></center> |
+| <center><img src="{% link /images/week02/02-1/Figure4.png %}" alt="Figure4" style="zoom:30%;" /></center> |
 |  Figure 5: Looking inside the linear and non-linear blocks   |
 
 In the graph, $s[i]$ is the weighted sum of unit ${i}$ which is computed as:
@@ -170,7 +170,7 @@ where $f$ is a non-linear function.
 
 The first way to do backpropagation is to backpropagate through a non linear function. We take a particular non-linear function $h$ from the network and leave everything else in the blackbox.
 
-| <center><img src="/images/week02/02-1/Figure5.png" alt="Figure5" style="zoom: 25%;" /></center> |
+| <center><img src="{% link /images/week02/02-1/Figure5.png %}" alt="Figure5" style="zoom: 25%;" /></center> |
 |    Figure 6: Backpropagation through non-linear function     |
 
 We are going to use the chain rule to compute the gradients:
@@ -205,7 +205,7 @@ Once again, we end up with the same formula as the one shown above.
 
 For a linear module, we do backpropagation through a weighted sum. Here we view the entire network as a blackbox except for 3 connections going from a ${z}$ variable to a bunch of $s$ variables.
 
-| <center><img src="/images/week02/02-1/Figure6.png" alt="Figure6" style="zoom: 25%;" /></center> |
+| <center><img src="{% link /images/week02/02-1/Figure6.png %}" alt="Figure6" style="zoom: 25%;" /></center> |
 |        Figure 7: Backpropagation through weighted sum        |
 
 
@@ -244,7 +244,7 @@ $$
 - Linear blocks $s_{k+1}=w_kz_k$
 - Non-linear blocks $z_k=h(s_k)$
 
-  <center><img src="/images/week02/02-1/Figure 7.png" alt="Figure 7" style="zoom: 33%;" /></center>
+  <center><img src="{% link /images/week02/02-1/Figure 7.png %}" alt="Figure 7" style="zoom: 33%;" /></center>
 
 $w_k$: matrix $z_k$: vector $h$: application of scalar ${h}$ function to every component. This is a 3-layer neural net with pairs of linear and non-linear functions, though most modern neural nets do not have such clear linear and non-linear separations and are more complex.
 
@@ -285,7 +285,7 @@ out = model(image)
 
 We now present a more generalized form of backpropagation.
 
-| <center><img src="/images/week02/02-1/Figure9.png" alt="Figure9" style="zoom:33%;" /></center> |
+| <center><img src="{% link /images/week02/02-1/Figure9.png %}" alt="Figure9" style="zoom:33%;" /></center> |
 |    Figure 8: Backpropagation through a functional module     |
 
 
@@ -324,7 +324,7 @@ We now present a more generalized form of backpropagation.
 
 Consider a stack of many modules in a neural network as shown in Figure 10.
 
-| <center><img src="/images/week02/02-1/Figure10.png" alt="Figure10" style="zoom:33%;" /></center> |
+| <center><img src="{% link /images/week02/02-1/Figure10.png %}" alt="Figure10" style="zoom:33%;" /></center> |
 |         Figure 9: Backprop through multi-stage graph         |
 
 For the backprop algorithm, we need two sets of gradients - one with respect to the states (each module of the network) and one with respect to the weights (all the parameters in a particular module). So we have two Jacobian matrices associated with each module. We can again use chain rule for backprop.

--- a/docs/en/week02/02-2.md
+++ b/docs/en/week02/02-2.md
@@ -13,7 +13,7 @@ date: 3 February 2020
 
 We next consider a concrete example of backpropagation assisted by a visual graph. The arbitrary function $G(w)$ is inputted into the cost function $C$, which can be represented as a graph. Through the manipulation of multiplying the Jacobian matrices, we can transform this graph into the graph that will compute the gradients going backwards. (Note that PyTorch and TensorFlow do this automatically for the user, i.e., the forward graph is automatically "reversed" to create the derivative graph that backpropagates the gradient.)
 
-<center><img src="/images/week02/02-2/02-2-1.png" alt="Gradient diagram" style="zoom:40%;" /></center>
+<center><img src="{% link /images/week02/02-2/02-2-1.png %}" alt="Gradient diagram" style="zoom:40%;" /></center>
 
 In this example, the green graph on the right represents the gradient graph. Following the graph from the topmost node, it follows that
 
@@ -108,7 +108,7 @@ $$
 
 However, the use of softmax leaves the network susceptible to vanishing gradients. Vanishing gradient is a problem, as it prevents weights downstream from being modified by the neural network, which may completely stop the neural network from further training. The logistic sigmoid function, which is the softmax function for one value, shows that when s is large, $h(s)$ is 1, and when s is small, $h(s)$ is 0. Because the sigmoid function is flat at $h(s) = 0 $ and $h(s) = 1$, the gradient is 0, which results in a vanishing gradient.
 
-<center><img src="/images/week02/02-2/02-2-2.png" alt="Sigmoid function to illustrate vanishing gradient" style="background-color:#DCDCDC;" /></center>
+<center><img src="{% link /images/week02/02-2/02-2-2.png %}" alt="Sigmoid function to illustrate vanishing gradient" style="background-color:#DCDCDC;" /></center>
 
 $$
 h(s) = \frac{1}{1 + \exp(-s)}
@@ -126,7 +126,7 @@ $$
 \log\left(\frac{\exp(s)}{\exp(s) + 1}\right)= s - \log(1 + \exp(s))
 $$
 
-<center><img src="/images/week02/02-2/02-2-3.png" width='400px' alt="Plot of logarithmic part of the functions" /></center>
+<center><img src="{% link /images/week02/02-2/02-2-3.png %}" width='400px' alt="Plot of logarithmic part of the functions" /></center>
 
 
 ## [Practical tricks for backpropagation](https://www.youtube.com/watch?v=d9vdh3b787Y&t=4924s)

--- a/docs/en/week02/02-3.md
+++ b/docs/en/week02/02-3.md
@@ -18,13 +18,13 @@ typora-root-url: 02-3
   <table border="0">
     <td>
       <center>
-    <img src="/images/week02/02-3/clean-spiral.png" width="350px" /><br>
+    <img src="{% link /images/week02/02-3/clean-spiral.png %}" width="350px" /><br>
        <b>Fig. 1(a)</b> "Clean" 2D spiral
        </center>
       </td>
       <td>
       <center>
-      <img src="/images/week02/02-3/noisy-spiral.png" width="350px" /><br>
+      <img src="{% link /images/week02/02-3/noisy-spiral.png %}" width="350px" /><br>
        <b>Fig. 1(b)</b> "Noisy" 2D spiral
        </center>
       </td>
@@ -59,7 +59,7 @@ Last week, we saw that a newly initialised neural network transforms its input i
 * $\boldsymbol X$ represents the input data, a matrix of dimensions $\mathbf m$ (number of training data points) x $\mathbf n$ (dimensionality of each input point). In case of the data shown in Figures **1(a)** and **1(b)**, $\mathbf n = 2$.
 
 <center>
-<img src="/images/week02/02-3/training-data.png" width="600px" /><br>
+<img src="{% link /images/week02/02-3/training-data.png %}" width="600px" /><br>
 <b>Fig. 2</b> Training data
 </center>
 
@@ -69,7 +69,7 @@ Last week, we saw that a newly initialised neural network transforms its input i
   * To bypass this issue, we use **one-hot encoding**. For each data point, a vector of dimension $$K$$ is created, with the $$i$$-th element of the $\boldsymbol Y $ vector set to $\mathbf 1$, where $i \in \{1, 2, ..., K\}$​ is the class label for that data point (see **Fig. 3** below).
 
 <center>
-<img src="/images/week02/02-3/one-hot.png" width="250px" /><br>
+<img src="{% link /images/week02/02-3/one-hot.png %}" width="250px" /><br>
 <b>Fig. 3</b> One hot encoding
 </center>
 
@@ -81,7 +81,7 @@ Last week, we saw that a newly initialised neural network transforms its input i
 We will now take a look at what a fully connected (FC) network is, and how it works.
 
 <center>
-<img src="/images/week02/02-3/FC-net.png" height="250px" /><br>
+<img src="{% link /images/week02/02-3/FC-net.png %}" height="250px" /><br>
 <b>Fig. 4</b> Fully connected neural network
 </center>
 
@@ -113,7 +113,7 @@ Now let's move to a more complicated case.
 Let's do a case of 3 hidden layers, fully connected in each layer. An illustration can be found in **Fig. 5**
 
 <center>
-<img src="/images/week02/02-3/pre-inference4layers.png" /><br>
+<img src="{% link /images/week02/02-3/pre-inference4layers.png %}" /><br>
 <b>Fig. 5</b> Neural net with 3 hidden layers
 </center>
 
@@ -133,7 +133,7 @@ The activation of the last layer in general would depend on your use case, as ex
 Let's think about the two-layer neural network again, as seen in **Fig. 6**
 
 <center>
-<img src="/images/week02/02-3/2-layer-inference.png" height="250px"/><br>
+<img src="{% link /images/week02/02-3/2-layer-inference.png %}" height="250px"/><br>
 <b>Fig. 6</b> Two-layer neural network
 </center>
 
@@ -223,7 +223,7 @@ This makes the loss depend on the output of the network  $\boldsymbol {\hat{Y}} 
 A simple illustration of how this works can be seen in **Fig. 7**, where $J(\mathcal{v})$ is the function we need to minimize.
 
 <center>
-<img src="/images/week02/02-3/1-GD.png" style="zoom: 60%; background-color:#DCDCDC;" /><br>
+<img src="{% link /images/week02/02-3/1-GD.png %}" style="zoom: 60%; background-color:#DCDCDC;" /><br>
 <b>Fig. 7</b> Optimizing a loss function through gradient descent.
 </center>
 
@@ -245,7 +245,7 @@ An explanation of how to use `torch.device()` can be found in [last week's notes
 Like before, we are going to be working with points in $\mathbb{R}^2$ with three different categorical labels - in red, yellow and blue - as can be seen in **Fig. 8**.
 
 <center>
-<img src="/images/week02/02-3/2-data.png" style="zoom: 50%; background-color:#DCDCDC;" /><br>
+<img src="{% link /images/week02/02-3/2-data.png %}" style="zoom: 50%; background-color:#DCDCDC;" /><br>
 <b>Fig. 8</b> Spiral classification data.
 </center>
 
@@ -256,21 +256,21 @@ Remember, an affine transformation is five things: rotation, reflection, transla
 As it can be seen in **Fig. 9**, when trying to separate the spiral data with linear decision boundaries - only using `nn.linear()` modules, without a non-linearity between them - the best we can achieve is an accuracy of 50%.
 
 <center>
-<img src="/images/week02/02-3/3-linear.png" style="zoom: 60%; background-color:#DCDCDC;" /><br>
+<img src="{% link /images/week02/02-3/3-linear.png %}" style="zoom: 60%; background-color:#DCDCDC;" /><br>
 <b>Fig. 9</b> Linear decision boundaries.
 </center>
 
 When we go from a linear model to one with two `nn.linear()` modules and a `nn.ReLU()` between them, the accuracy goes up to 95%. This is because the boundaries become non-linear and adapt much better to the spiral form of the data, as it can be seen in **Fig. 10**.
 
 <center>
-<img src="/images/week02/02-3/4-non-linear.png" style="zoom: 64%; background-color:#DCDCDC;" /><br>
+<img src="{% link /images/week02/02-3/4-non-linear.png %}" style="zoom: 64%; background-color:#DCDCDC;" /><br>
     <b>Fig. 10</b> Non-linear decision boundaries.
 </center>
 
 An example of a regression problem which can't be solved correctly with a linear regression, but is easily solved with the same neural network structure can be seen in [this notebook](https://github.com/Atcold/pytorch-Deep-Learning-Minicourse/blob/master/05-regression.ipynb) and **Fig. 11**, which shows 10 different networks, where 5 have a `nn.ReLU()` link function and 5 have a `nn.Tanh()`. The former is a piecewise linear function, whereas the latter is a continuous and smooth regression.
 
 <center>
-<img src="/images/week02/02-3/5-nn-reg.png" style="zoom: 64%; background-color:#DCDCDC;" /><br>
+<img src="{% link /images/week02/02-3/5-nn-reg.png %}" style="zoom: 64%; background-color:#DCDCDC;" /><br>
 <b>Fig. 11</b>: 10 Neural networks, along with their variance/SD.<br>
 Left: 5 ReLU networks.  Right: Five tanh networks.
 </center>
@@ -278,7 +278,7 @@ Left: 5 ReLU networks.  Right: Five tanh networks.
 The yellow and green lines show the standard deviation and variance for the networks. Using these is useful for something similar to a "confidence interval" - since the functions give a single prediction per output. Using ensemble variance prediction allows us to estimate the uncertainty with which the prediction is being made. The importance of this can be seen in **Fig. 12**, where we extend the decision functions outside the training interval and these tend towards $+\infty, -\infty$.
 
 <center>
-<img src="/images/week02/02-3/6-nn-confidence.png" style="zoom: 64%; background-color:#DCDCDC;" /><br>
+<img src="{% link /images/week02/02-3/6-nn-confidence.png %}" style="zoom: 64%; background-color:#DCDCDC;" /><br>
 <b>Fig. 12</b> Neural networks, with variance/SD, outside training interval.<br>
 Left: 5 ReLU networks.  Right: Five tanh networks.
 </center>

--- a/docs/en/week03/03-1.md
+++ b/docs/en/week03/03-1.md
@@ -14,24 +14,24 @@ typora-root-url: 03-1
 
 In this section we will show the visualization of neural network and the results of linear transformation and ReLU operator.
 
-<center><img src="/images/week03/03-1/Network.png" alt="Network" style="zoom:35%;" /><br>
+<center><img src="{% link /images/week03/03-1/Network.png %}" alt="Network" style="zoom:35%;" /><br>
 Fig. 1 Network Structure</center>
 
 Figure 1 is a neural network for visualization. Usually, the input of neural networks is in the bottom side or on the left, and the output is in the top side or on the right. In Figure 1, pink neurons are inputs, and blue neurons are outputs. In this network, we have 4 hidden layers, which means we have 6 layers in total (4 hidden layers + 1 input layer + 1 output layer). We use 2-by-2 matrix as our weight matrix $W$. This is because we want to transform input plane into another plane. The linear transformation includes shearing, rotation, reflection and scaling.
 
-<center><img src="/images/week03/03-1/Visual1.png" alt="Network" style="zoom:35%;" /><br>
+<center><img src="{% link /images/week03/03-1/Visual1.png %}" alt="Network" style="zoom:35%;" /><br>
 Fig. 2 Visualization of folding space</center>
 
 The transformation of each layer is like folding our plane into some specific regions as shown in Figure 2. In the experiment, we find that if we have only 2 neurons in each hidden layer, the optimization will take longer; the optimization is easier if we have more neurons in hidden layers. So we have one question: Why is it hard to train if we have few neurons? We will answer after the visualization of $\texttt{ReLU}$.
 
-| <img src="/images/week03/03-1/Visual2a.png" alt="Network" style="zoom:45%;" /> | <img src="/images/week03/03-1/Visual2b.png" alt="Network" style="zoom:45%;" /> |
+| <img src="{% link /images/week03/03-1/Visual2a.png %}" alt="Network" style="zoom:45%;" /> | <img src="{% link /images/week03/03-1/Visual2b.png %}" alt="Network" style="zoom:45%;" /> |
 |(a)|(b)|
 
 <center>Fig. 3 Visualization of ReLU operator</center>
 
 When we split each hidden layers, we can see each layers do some steps of linear transformation, and then do ReLU operation, which eliminates the negative values to zero. In Figure 3(a)(b), we can see the visualization of ReLU operator. ReLU operator helps us do nonlinear transformation. After some transformations, we eventually obtain linearly separable data in Figure 4.
 
-<center><img src="/images/week03/03-1/Visual3.png" alt="Network" style="zoom:30%;" /><br>
+<center><img src="{% link /images/week03/03-1/Visual3.png %}" alt="Network" style="zoom:30%;" /><br>
 Fig. 4 Visualization of Outputs</center>
 
 So now we know the reason why 2-neuron hidden layers are hard to train. Our 6-layer network has one bias in each hidden layers. Therefore if one of these biases moves points out of top-right quadrant, then ReLU will eliminate these points to zero. After that, no matter how the latter layers transform, the values will remain zero. To make a neural network easier to train we can make either the network "fat" by adding more neurons in hidden layers, or we can add more hidden layers, or a combination of the two methods. For the rest of the semester we will dig further into what is the best architecture for the network, stay tuned.
@@ -56,7 +56,7 @@ $$
 
 These formula is applied in a matrix form. Note that the dimension of right terms should be consistent. The dimension of $u$,$w$,$\frac{\partial H}{\partial u}^\top$,$\frac{\partial C}{\partial w}^\top$ are $[N_u \times 1]$,$[N_w \times 1]$,$[N_u \times N_w]$,$[N_w \times 1]$, respectively. Therefore, the dimension of backprop formula is consistent.
 
-<center><img src="/images/week03/03-1/PT.png" alt="Network" style="zoom:35%;" /><br>
+<center><img src="{% link /images/week03/03-1/PT.png %}" alt="Network" style="zoom:35%;" /><br>
 Fig. 5 General Form of Parameter Transformations</center>
 
 
@@ -75,7 +75,7 @@ We force shared parameters to be equal, so the gradient w.r.t. shared parameters
 
 Hypernetwork is a network where the weights of one network is the output of another network. Figure 6 shows a framework of "hypernetwork". Here the function $H$ as a network with the parameter vector $u$ and the input $x$. As a result, the weights of $G(x,w)$ are dynamically configured by network $H(x,u)$. This idea is old but very powerful even at present.
 
-<center><img src="/images/week03/03-1/HyperNetwork.png" alt="Network" style="zoom:35%;" /><br>
+<center><img src="{% link /images/week03/03-1/HyperNetwork.png %}" alt="Network" style="zoom:35%;" /><br>
 Fig. 6 "Hypernetwork"</center>
 
 
@@ -83,7 +83,7 @@ Fig. 6 "Hypernetwork"</center>
 
 Weight sharing transformation can be applied to motif detection. Motif detection means to find some motifs in sequential data like keywords in speech or text. As Figure 7 shows, one solution is to use a sliding window on data, which moves the weight-shared function to detect a particular motif (i.e. a particular sound in speech signal), and the outputs (i.e. a score) goes into a maximum function.
 
-<center><img src="/images/week03/03-1/Motif.png" alt="Network" style="zoom:30%;" /><br>
+<center><img src="{% link /images/week03/03-1/Motif.png %}" alt="Network" style="zoom:30%;" /><br>
 Fig. 7 Motif Detection for Sequential Data</center>
 
 In this example we have 5 of those functions. As a result of this solution, we sum up five gradients and backpropagate to the parameter $w$. We do not want the implicit accumulation of these gradients, so we need to use `zero_grad()` in PyTorch to initialize the gradient.
@@ -93,12 +93,12 @@ In this example we have 5 of those functions. As a result of this solution, we s
 
 The other useful situation is motif detection in images. We usually swipe our "templates" over images to detect the shapes independent of position and distortion of shapes. A simple example is to distinguish between "C" and "D",  as Figure 8 shows. The difference between "C" and "D" is that "C" has two endpoints and "D" has two corners. So we can design "endpoint templates" and "corner templates". If the shape is similar to the "templates", it will have thresholded outputs. Then we can distinguish letters from these outputs by summing them up. In Figure 8, the network detects two endpoints and zero corners, so it activates "C".
 
-<center><img src="/images/week03/03-1/MotifImage.png" alt="Network" style="zoom:35%;" /><br>
+<center><img src="{% link /images/week03/03-1/MotifImage.png %}" alt="Network" style="zoom:35%;" /><br>
 Fig. 8 Motif Detection for Images</center>
 
 It is also important that our "template matching" should be shift-invariant - when we shift the input, the output or the letter detected shouldn't change. This can be perfectly solved with weight sharing transformation. As Figure 9 shows, when we change the location of "D", we can still detect the corner motifs even though they are shifted. When we sum up the motifs, it will activate the "D" detection.
 
-<center><img src="/images/week03/03-1/ShiftInvariance.png" alt="Network" style="zoom:35%;" /><br>
+<center><img src="{% link /images/week03/03-1/ShiftInvariance.png %}" alt="Network" style="zoom:35%;" /><br>
 Fig. 9 Shift Invariance</center>
 
 This using local detectors and sum up detection to detect which letter the image represent is a hand-crafted method we use for many years. So it comes a problem: How can we design these "templates" automatically? Can we use neural networks to learn these "templates"? Next, We will introduce **convolution** , that is, the operation which we match images with "templates".
@@ -156,7 +156,7 @@ The reason for stacking multiple such layers is that we want to build a hierarch
 
 Why would we want to capture the hierarchical representation of the world? Because the world we live in is compositional. This point is alluded to in previous sections. Such hierarchical nature can be observed from the fact that local pixels assembled to form simple motifs such as oriented edges. These edges in turn assembled to form local features such as corners, T-junction, etc. Those assembled to form motifs that are even more abstract. This keeps going until eventually parts of object and objects we observed in the real world are formed.
 
-<center><img src="/images/week03/03-1/cnn_features.png" alt="CNN Features" style="zoom:35%;" /><br>
+<center><img src="{% link /images/week03/03-1/cnn_features.png %}" alt="CNN Features" style="zoom:35%;" /><br>
 Figure 10. Feature visualization of convolutional net trained on ImageNet from [Zeiler & Fergus 2013]</center>
 
 
@@ -175,7 +175,7 @@ The fact that human understands the world thanks to this compositional nature st
 
 So why should Deep Learning be rooted in the idea that our world is comprehensible and has a compositional nature? Research conducted by Simon Thorpe helped motivate this further. He showed that the way we recognize everyday objects is extremely fast. His experiments involved flashing a set of images every 100ms, and then asking users to identify these images, which they were able to do successfully. This demonstrated that it takes about 100ms for humans to detect objects. Furthermore, consider the diagram below, illustrating parts of the brain annotated with the time it takes for neurons to propagate from one area to the next:
 
-<center><img src="/images/week03/03-1/Simon_Thorpe.png" alt="Simon_Thorpe" style="zoom:55%;" /></center>
+<center><img src="{% link /images/week03/03-1/Simon_Thorpe.png %}" alt="Simon_Thorpe" style="zoom:55%;" /></center>
 
 <div align="center">Figure 11. Simon Thorpe's model of visual information flow in the brain <div>
 
@@ -187,7 +187,7 @@ These insights suggested that we could develop a neural network architecture whi
 
 One further insight from the human brain comes from Gallant & Van Essen, whose model of the human brain illustrates two distinct pathways:
 
-<center><img src="/images/week03/03-1/Gallant_and_Van_Essen.png" alt="Gallant_and_Van_Essen" style="zoom:55%;" /></center>
+<center><img src="{% link /images/week03/03-1/Gallant_and_Van_Essen.png %}" alt="Gallant_and_Van_Essen" style="zoom:55%;" /></center>
 
 <div align="center">Figure 12. Gallen & Van Essen's model of dorsal & ventral pathways in the brain <div>
 
@@ -196,7 +196,7 @@ The right side shows the ventral pathway, which tells you what you're looking at
 
 ### Hubel & Weisel's contributions (1962)
 
-<center><img src="/images/week03/03-1/Hubel_and_Weisel.png" alt="Hubel_and_Weisel" style="zoom:55%;" /></center>
+<center><img src="{% link /images/week03/03-1/Hubel_and_Weisel.png %}" alt="Hubel_and_Weisel" style="zoom:55%;" /></center>
 
 <div align="center">Figure 13. Hubel & Weisel's experiments with visual stimuli in cat brains <div>
 
@@ -209,7 +209,7 @@ Another type of neuron, which they named "complex cells", aggregate the output o
 
 ### Fukushima's contributions (1982)
 
-<center><img src="/images/week03/03-1/Fukushima.png" alt="Fukushima" style="zoom:55%;" /></center>
+<center><img src="{% link /images/week03/03-1/Fukushima.png %}" alt="Fukushima" style="zoom:55%;" /></center>
 
 <div align="center">Figure 14. Fukushima's CNN model <div>
 

--- a/docs/en/week03/03-2.md
+++ b/docs/en/week03/03-2.md
@@ -36,7 +36,7 @@ After moving to Bell Labs, LeCunn's research shifted to using handwritten zipcod
 The next year, some changes were made: separate pooling was introduced. Separate pooling is done by averaging input values, adding a bias, and passing to a nonlinear function (hyperbolic tangent function). The 2$\times$2 pooling was performed with a stride of 2, hence reducing resolutions by half.
 
 <center>
-    <img src="/images/week03/03-2/detailed_convNet.png" width="600px" /><br>
+    <img src="{% link /images/week03/03-2/detailed_convNet.png %}" width="600px" /><br>
     <b>Fig. 1</b> ConvNet Architecture
 </center>
 

--- a/docs/en/week03/03-3.md
+++ b/docs/en/week03/03-3.md
@@ -29,12 +29,12 @@ If our data exhibits stationarity, locality, and compositionality, we can exploi
 
 Fig.1 shows a 5-layer fully connected network. Each arrow represents a weight to be multiplied by the inputs. As we can see, this network is very computationally expensive.
 
-<center><img src="/images/week02/02-3/pre-inference4layers.png" width="400px" /><br>
+<center><img src="{% link /images/week02/02-3/pre-inference4layers.png %}" width="400px" /><br>
 <b>Figure 1:</b> Fully Connected Network</center>
 
 If our data exhibits locality, each neuron needs to be connected to only a few local neurons of the previous layer. Thus, some connections can be dropped as shown in Fig.2. Fig.2(a) represents an FC network. Taking advantage of the locality property of our data, we drop connections between far away neurons in Fig.2(b). Although the hidden layer neurons (green) in Fig.2(b) don't span the whole input, the overall architecture will be able to account for all input neurons. The receptive field (RF) is the number of neurons of previous layers, that each neuron of a particular layer can see or has taken into account. Therefore, the RF of the output layer w.r.t the hidden layer is 3, RF of the hidden layer w.r.t the input layer is 3, but the RF of the output layer w.r.t the input layer is 5.
 
-|<img src="/images/week03/03-3/Figure 2(a) Before Applying Sparsity.png" width="300"/> | <img src="/images/week03/03-3/Figure 2(b) After Applying Sparsity.png" width="300"/>|
+|<img src="/images/week03/03-3/Figure 2({% link a) Before Applying Sparsity.png %}" width="300"/> | <img src="/images/week03/03-3/Figure 2({% link b) After Applying Sparsity.png %}" width="300"/>|
 |<b>Figure 2(a):</b> Before Applying Sparsity | <b>Figure 2(b):</b> After Applying Sparsity|
 
 
@@ -43,7 +43,7 @@ If our data exhibits locality, each neuron needs to be connected to only a few l
 If our data exhibits stationarity, we could use a small set of parameters multiple times across the network architecture. For example in our sparse network, Fig.3(a), we can use a set of 3 shared parameters (yellow, orange and red). The number of parameters will then drop from 9 to 3! The new architecture might even work better because we have more data for training those specific weights.
 The weights after applying sparsity and parameter sharing is called a convolution kernel.
 
-|<img src="/images/week03/03-3/Figure 3(a) Before Applying Parameter Sharing.png" width="300"/> | <img src="/images/week03/03-3/Figure 3(b) After Applying Parameter Sharing.png" width="300"/>|
+|<img src="/images/week03/03-3/Figure 3({% link a) Before Applying Parameter Sharing.png %}" width="300"/> | <img src="/images/week03/03-3/Figure 3({% link b) After Applying Parameter Sharing.png %}" width="300"/>|
 |<b>Figure 3(a):</b> Before Applying Parameter Sharing | <b>Figure 3(b):</b> After Applying Parameter Sharing|
 
 Following are some advantages of using sparsity and parameter sharing:-
@@ -59,7 +59,7 @@ Fig.4 shows an example of kernels on 1D data, where the kernel size is: 2(number
 
 The choice of kernel size is empirical. 3 * 3 convolution seems to be the minimal size for spatial data. Convolution of size 1 can be used to obtain a final layer that can be applied to a larger input image. Kernel size of even number might lower the quality of the data, thus we always have kernel size of odd numbers, usually 3 or 5.
 
-<center><img src="/images/week03/03-3/Figure 4 Kernals on 1D Data.png" width="350px" /><br>
+<center><img src="{% link /images/week03/03-3/Figure 4 Kernals on 1D Data.png %}" width="350px" /><br>
 <b>Figure 4:</b> Kernals on 1D Data</center>
 
 
@@ -84,7 +84,7 @@ Parts of a signal can get lost if too many layers have been stacked so, addition
 
 In Fig.5, while the input image contains mostly spatial information across two dimensions (apart from characteristic information, which is the colour of each pixel), the output layer is thick. Midway, there is a trade off between the spatial information and the characteristic information and the representation becomes denser. Therefore, as we move up the hierarchy, we get denser representation as we lose the spatial information.
 
-<center><img src="/images/week03/03-3/Figure 5 Information Representations Moving up the Hierachy.png" width="350px" /><br>
+<center><img src="{% link /images/week03/03-3/Figure 5 Information Representations Moving up the Hierachy.png %}" width="350px" /><br>
 <b>Figure 5:</b> Information Representations Moving up the Hierachy</center>
 
 
@@ -93,13 +93,13 @@ In Fig.5, while the input image contains mostly spatial information across two d
 
 ### Pooling
 
-<center><img src="/images/week03/03-3/Figure 6 Illustration of Pooling.png" width="350px" /><br>
+<center><img src="{% link /images/week03/03-3/Figure 6 Illustration of Pooling.png %}" width="350px" /><br>
 <b>Figure 6:</b> Illustration of Pooling</center>
 
 A specific operator, $L_p$-norm, is applied to different regions (refer to Fig.6). Such an operator gives only one value per region(1 value for 4 pixels in our example). We then iterate over the whole data region-by-region, taking steps based on the stride. If we start with $m * n$ data with $c$ channels, we will end up with $\frac{m}{2} * \frac{n}{2}$ data still with $c$ channels (refer to Fig.7).
 Pooling is not parametrized; nevertheless, we can choose different polling types like max pooling, average pooling and so on. The main purpose of pooling reduces the amount of data so that we can compute in a reasonable amount of time.
 
-<center><img src="/images/week03/03-3/Figure 7 Pooling results.png" width="350px" /><br>
+<center><img src="{% link /images/week03/03-3/Figure 7 Pooling results.png %}" width="350px" /><br>
 <b>Figure 7:</b> Pooling results </center>
 
 
@@ -109,7 +109,7 @@ The Jupyter notebook can be found [here](https://github.com/Atcold/pytorch-Deep-
 
 In this notebook, we train a multilayer perceptron (FC network) and a convolution neural network (CNN) for the classification task on the MNIST dataset. Note that both networks have an equal number of parameters. (Fig.8)
 
-<center> <img src="/images/week03/03-3/Figure 8 Instances from the Original MNIST Dataset.png" width="350px" /><br>
+<center> <img src="{% link /images/week03/03-3/Figure 8 Instances from the Original MNIST Dataset.png %}" width="350px" /><br>
 <b>Figure 8:</b> Instances from the Original MNIST Dataset </center>
 
 Before training, we normalize our data so that the initialization of the network will match our data distribution (very important!). Also, make sure that the following five operations/steps are present in your training: -
@@ -123,7 +123,7 @@ First, we train both the networks on the normalized MNIST data. The accuracy of 
 
 Next, we perform a random permutation of all the pixels in all the images of our MNIST dataset. This transforms our Fig.8 to Fig.9. We then train both the networks on this modified dataset.
 
-<center><img src="/images/week03/03-3/Figure 9 Instances from Permuted MNIST Dataset.png" width="350px" /><br>
+<center><img src="{% link /images/week03/03-3/Figure 9 Instances from Permuted MNIST Dataset.png %}" width="350px" /><br>
 <b>Figure 9:</b> Instances from Permuted MNIST Dataset</center>
 
 The performance of the FC network almost stayed unchanged ($85\%$), but the accuracy of CNN dropped to $83\%$. This is because, after a random permutation, the images no longer hold the three properties of locality, stationarity, and compositionality, that are exploitable by a CNN.

--- a/docs/en/week04/04-1.md
+++ b/docs/en/week04/04-1.md
@@ -223,12 +223,12 @@ In this notebook, we are going to explore Convolution as 'running scalar product
 Importing library `librosa` and we can load data $\boldsymbol{x}$ and sampling rate. In this case, there are 70641 samples, learning rate is 22.05kHz and total time is 3.2s. The imported audio signal is wavy (refer to Fig 1) and we can guess what it sounds like from the amplitude of y axis. Listening to x(t), the audio signal is actually the sound played when turning off the Windows system (refer to Fig 2).
 
 <center>
-<img src="/images/week04/04-1/audioSignal.png" width="500px" /><br>
+<img src="{% link /images/week04/04-1/audioSignal.png %}" width="500px" /><br>
 <b>Fig. 1</b>: A visualization of the audio Signal. <br>
 </center>
 
 <center>
-<img src="/images/week04/04-1/notes.png" width="500px" /><br>
+<img src="{% link /images/week04/04-1/notes.png %}" width="500px" /><br>
 <b>Fig. 2</b>: Notes for the above audio.<br>
 </center>
 
@@ -236,7 +236,7 @@ Importing library `librosa` and we can load data $\boldsymbol{x}$ and sampling r
 To get notes from wave from, Fourier transform (FT) is a good guess, however, if FT is played on the whole signal, notes would come out together, the is hard to figure out the exact time and location of each pitch. Localized FT is needed, which is called spectroscope. As is shown in the spectrogram (refer to Fig 3), different pitched peak at different values (e.g. first pitch peaks at 1600). Concatenate the four pitches based on their frequencies, we get the reconstruction.
 
 <center>
-<img src="/images/week04/04-1/spectrogram.png" width="500px" /><br>
+<img src="{% link /images/week04/04-1/spectrogram.png %}" width="500px" /><br>
 <b>Fig. 3</b>: Audio signal and its spectrum.<br>
 </center>
 
@@ -244,17 +244,17 @@ Convolution of signal with different pitches can help to extract all notes from 
 
 
 <center>
-<img src="/images/week04/04-1/fig4.png" width="500px" /><br>
+<img src="{% link /images/week04/04-1/fig4.png %}" width="500px" /><br>
 <b>Fig. 4</b>: Spectrogram of real signal and concatenation.<br>
 </center>
 
 <center>
-<img src="/images/week04/04-1/fig5.png" width="500px" /><br>
+<img src="{% link /images/week04/04-1/fig5.png %}" width="500px" /><br>
 <b>Fig. 5</b>: First melody's note.<br>
 </center>
 
 <center>
-<img src="/images/week04/04-1/fig6.png" width="500px" /><br>
+<img src="{% link /images/week04/04-1/fig6.png %}" width="500px" /><br>
 <b>Fig. 6</b>: Convolution of four kernels.<br>
 </center>
 
@@ -271,6 +271,6 @@ The last part is a short digression that give some examples of dimensionality of
 * Special relativity: domain is $\mathbb{R^4} \times \mathbb{R^4}$ (space-time $\times$ four-momentum); channel $c = 1$ (*e.g.* Hamiltonian).
 
 <center>
-<img src="/images/week04/04-1/fig7.png" width="600px" /><br>
+<img src="{% link /images/week04/04-1/fig7.png %}" width="600px" /><br>
 <b>Fig. 7</b>: Different dimension of different signals.<br>
 </center>

--- a/docs/en/week05/05-1.md
+++ b/docs/en/week05/05-1.md
@@ -33,7 +33,7 @@ The assumption here is that the function $f$ is continuous and differentiable. O
 The $\gamma$ parameter in the iterative update equation is called the **step size**. Generally we don't know the value of the optimal step-size; so we have to try different values. Standard practice is to try a bunch of values on a log-scale and then use the best one. There are a few different scenarios that can occur. The image above depicts these scenarios for a 1D quadratic. If the learning rate is too low, then we would make steady progress towards the minimum. However, this might take more time than what is ideal. It is generally very difficult (or impossible) to get a step-size that would directly take us to the minimum. What we would ideally want is to have a step-size a little larger than the optimal. In practice, this gives the quickest convergence. However, if we use too large a learning rate, then the iterates get further and further away from the minima and we get divergence. In practice, we would want to use a learning rate that is just a little less than diverging.
 
 <center>
-<img src="/images/week05/05-1/step-size.png" style="zoom: 70%; background-color:#DCDCDC;" /><br>
+<img src="{% link /images/week05/05-1/step-size.png %}" style="zoom: 70%; background-color:#DCDCDC;" /><br>
 <b>Figure 1:</b> Step sizes for 1D Quadratic
 </center>
 
@@ -77,7 +77,7 @@ $$
 Thus, any SGD update is the same as full-batch update in expectation. However, SGD is not just faster gradient descent with noise. Along with being faster, SGD can also get us better results than full-batch gradient descent. The noise in SGD can help us avoid the shallow local minima and find a better (deeper) minima. This phenomenon is called **annealing**.
 
 <center>
-<img src="/images/week05/05-1/annealing.png"/><br>
+<img src="{% link /images/week05/05-1/annealing.png %}"/><br>
 <b>Figure 2:</b> Annealing with SGD
 </center>
 
@@ -130,7 +130,7 @@ This form is mathematically equivalent to the previous form. Here, the next step
 SGD Momentum is similar to the concept of momentum in physics. The optimization process resembles a heavy ball rolling down the hill. Momentum keeps the ball moving in the same direction that it is already moving in. Gradient can be thought of as a force pushing the ball in some other direction.
 
 <center>
-<img src="/images/week05/05-1/momentum.png"/><br>
+<img src="{% link /images/week05/05-1/momentum.png %}"/><br>
 <b>Figure 3:</b> Effect of Momentum<br>
 <b>Source:</b><a href="https://distill.pub/2017/momentum/" target="_blank"> distill.pub </a><br>
 </center>
@@ -140,7 +140,7 @@ Rather than making dramatic changes in the direction of travel (as in the figure
 The $\beta$ parameter is called the Dampening Factor. $\beta$ has to be greater than zero, because if it is equal to zero, you are just doing gradient descent. It also has to be less than 1, otherwise everything will blow up. Smaller values of $\beta$ result in change in direction quicker. For larger values, it takes longer to make turns.
 
 <center>
-<img src="/images/week05/05-1/momentum-beta.png" style="zoom: 40%; background-color:#DCDCDC;"/><br>
+<img src="{% link /images/week05/05-1/momentum-beta.png %}" style="zoom: 40%; background-color:#DCDCDC;"/><br>
 <b>Figure 4:</b> Effect of Beta on Convergence
 </center>
 
@@ -187,7 +187,7 @@ The great thing about SGD with momentum is that this averaging is no longer nece
 Both Acceleration and Noise smoothing contribute to high performance of momentum.
 
 <center>
-<img src="/images/week05/05-1/sgd-vs-momentum.png" style="zoom: 35%; background-color:#DCDCDC;"/><br>
+<img src="{% link /images/week05/05-1/sgd-vs-momentum.png %}" style="zoom: 35%; background-color:#DCDCDC;"/><br>
 <b>Figure 5:</b> SGD vs Momentum
 </center>
 

--- a/docs/en/week05/05-2.md
+++ b/docs/en/week05/05-2.md
@@ -18,7 +18,7 @@ Networks that are often used in practice have different structure in different p
 Weights in the latter part of the network (4096 in figure 1 below) directly dictate the output and have a very strong effect on it. Hence, we need smaller learning rates for those. In contrast, earlier weights will have smaller individual effects on the output, especially when initialized randomly.
 
 <center>
-<img src="/images/week05/05-2/5_2_vgg.png" style="zoom:40%"><br>
+<img src="{% link /images/week05/05-2/5_2_vgg.png %}" style="zoom:40%"><br>
 <b>Figure 1: </b>VGG16
 </center>
 
@@ -67,7 +67,7 @@ Bias correction that is used to keep the moving average unbiased during early it
 When training neural networks, SGD often goes in the wrong direction in the beginning of the training process, whereas RMSprop hones in on the right direction. However, RMSprop suffers from noise just as regular SGD, so it bounces around the optimum significantly once it's close to a local minimizer. Just like when we add momentum to SGD, we get the same kind of improvement with ADAM. It is a good, not-noisy estimate of the solution, so **ADAM is generally recommended over RMSprop**.
 
 <center>
-<img src="/images/week05/05-2/5_2_comparison.png" style="zoom:45%"><br>
+<img src="{% link /images/week05/05-2/5_2_comparison.png %}" style="zoom:45%"><br>
 <b>Figure 2: </b> SGD vs RMSprop vs ADAM
 </center><br>
 
@@ -85,7 +85,7 @@ Rather than improving the optimization algorithms, *normalization layers* improv
 
 In neural networks, we typically alternate linear operations with non-linear operations. The non-linear operations are also known as activation functions, such as ReLU. We can place normalization layers before the linear layers, or after the activation functions. The most common practice is to put them between the linear layers and activation functions, as in the figure below.
 
-| <center><img src="/images/week05/05-2/5_2_norm_layer_a.png" width="200px"/></center> | <center><img src="/images/week05/05-2/5_2_norm_layer_b.png" width="200px"/></center> | <center><img src="/images/week05/05-2/5_2_norm_layer_c.png" width="225px"/></center> |
+| <center><img src="{% link /images/week05/05-2/5_2_norm_layer_a.png %}" width="200px"/></center> | <center><img src="{% link /images/week05/05-2/5_2_norm_layer_b.png %}" width="200px"/></center> | <center><img src="{% link /images/week05/05-2/5_2_norm_layer_c.png %}" width="225px"/></center> |
 | (a) Before adding normalization                              |                (b) After adding normalization                |                    (c) An example in CNNs                    |
 
 <center><b>Figure 3:</b> Typical positions of normalization layers.</center>
@@ -108,7 +108,7 @@ where $x$ is the input vector, y is the output vector, $\mu$ is the estimate of 
 Without the learnable parameters $a$ and $b$, the distribution of output vector $y$ will have fixed mean 0 and std 1. The scaling factor $a$ and bias term $b$ maintain the representation power of the network, i.e., the output values can still be over any particular range. Note that $a$ and $b$ do not reverse the normalization, because they are learnable parameters and are much more stable than $\mu$ and $\sigma$.
 
 <center>
-<img src="/images/week05/05-2/5_2_norm_operations.png"/><br>
+<img src="{% link /images/week05/05-2/5_2_norm_operations.png %}"/><br>
 <b>Figure 4:</b> Normalization operations.
 </center>
 
@@ -152,7 +152,7 @@ Note that for batch norm and instance norm, the mean/std used are fixed after tr
 Sometimes we can barge into a field we know nothing about and improve how they are currently implementing things. One such example is the use of deep neural networks in the field of Magnetic Resonance Imaging (MRI) to accelerate MRI image reconstruction.
 
 <center>
-<img src="/images/week05/05-2/5_2_conv_xkcd.png" style="zoom:60%"><br>
+<img src="{% link /images/week05/05-2/5_2_conv_xkcd.png %}" style="zoom:60%"><br>
 <b>Figure 5: </b>Sometimes it actually works!
 </center>
 
@@ -162,7 +162,7 @@ Sometimes we can barge into a field we know nothing about and improve how they a
 In the traditional MRI reconstruction problem, raw data is taken from an MRI machine and an image is reconstructed from it using a simple pipeline/algorithm. MRI machines capture data in a 2-dimensional Fourier domain, one row or one column at a time (every few milliseconds). This raw input is composed of a frequency and a phase channel and the value represents the magnitude of a sine wave with that particular frequency and phase. Simply speaking, it can be thought of as a complex valued image, having a real and an imaginary channel. If we apply an inverse Fourier transform on this input, i.e add together all these sine waves weighted by their values, we can get the original anatomical image.
 
 <center>
-<img src="/images/week05/05-2/5_2_mri.png" style="zoom:60%"/><br>
+<img src="{% link /images/week05/05-2/5_2_mri.png %}" style="zoom:60%"/><br>
 <b>Figure 6: </b>MRI reconstruction
 </center><br>
 
@@ -174,7 +174,7 @@ A linear mapping currently exists to go from the Fourier domain to the image dom
 The new problem that needs to be solved is accelerated MRI, where by acceleration we mean making the MRI reconstruction process much faster. We want to run the machines quicker and still be able to produce identical quality images. One way we can do this and the most successful way so far has been to not capture all the columns from the MRI scan. We can skip some columns randomly, though it's useful in practice to capture the middle columns, as they contain a lot of information across the image, but outside them we just capture randomly. The problem is that we can't use our linear mapping anymore to reconstruct the image. The rightmost image in Figure 7 shows the output of a linear mapping applied to the subsampled Fourier space. It's clear that this method doesn't give us very useful outputs, and that there's room to do something a little bit more intelligent.
 
 <center>
-<img src="/images/week05/05-2/5_2_acc_mri.png" style="zoom:45%"><br>
+<img src="{% link /images/week05/05-2/5_2_acc_mri.png %}" style="zoom:45%"><br>
 <b>Figure 7: </b>Linear mapping on subsampled Fourier-space
 </center><br>
 
@@ -186,7 +186,7 @@ One of the biggest breakthroughs in theoretical mathematics for a long time was 
 Another condition is that we need to have *sparsity* in our image, where by sparsity we mean a lot of zeros or black pixels in the image. The raw input can be represented sparsely if we do a wavelength decomposition, but even this decomposition gives us an approximately sparse and not an exactly sparse image. So, this approach gives us a pretty good but not perfect reconstruction, as we can see in Figure 8. However, if the input were very sparse in the wavelength domain, then we would definitely get a perfect image.
 
 <center>
-<img src="/images/week05/05-2/5_2_comp_sensing.png" style="zoom:50%"><br>
+<img src="{% link /images/week05/05-2/5_2_comp_sensing.png %}" style="zoom:50%"><br>
 <b>Figure 8: </b>Compressed sensing
 </center><br>
 
@@ -214,7 +214,7 @@ where $B$ is our deep learning model and $y$ is the observed Fourier-domain data
 15 years ago, this approach was difficult - but nowadays this is a lot easier to implement. Figure 9 shows the result of a deep learning approach to this problem and we can see that the output is much better than the compressed sensing approach and looks very similar to the actual scan.
 
 <center>
-<img src="/images/week05/05-2/5_2_dl_approach.png" style="zoom:60%"><br>
+<img src="{% link /images/week05/05-2/5_2_dl_approach.png %}" style="zoom:60%"><br>
 <b>Figure 9: </b>Deep Learning approach
 </center><br>
 

--- a/docs/en/week05/05-3.md
+++ b/docs/en/week05/05-3.md
@@ -13,21 +13,21 @@ In this part we will discuss convolution, since we would like to explore the spa
 Instead of using the matrix $A$ above, we will change the matrix width to the kernel size $k$. Therefore, each row of the matrix is a kernel. We can use the kernels by stacking and shifting (see Fig 1). Then we can have $m$ layers of height $n-k+1$.
 
 <center>
-<img src="/images/week05/05-3/Illustration_1D_Conv.png" alt="1" style="zoom:40%;" /><br>
+<img src="{% link /images/week05/05-3/Illustration_1D_Conv.png %}" alt="1" style="zoom:40%;" /><br>
 <b>Fig 1</b>: Illustration of 1D Convolution
 </center>
 
 The output is $m$ (thickness) vectors of size $n-k+1$.
 
 <center>
-<img src="/images/week05/05-3/Result_1D_Conv.png" alt="2" style="zoom:40%;" /><br>
+<img src="{% link /images/week05/05-3/Result_1D_Conv.png %}" alt="2" style="zoom:40%;" /><br>
 <b>Fig 2</b>: Result of 1D Convolution
 </center>
 
 Furthermore, a single input vector can viewed as a monophonic signal.
 
 <center>
-<img src="/images/week05/05-3/Monophonic_Signal.png" alt="3" style="zoom:40%;" /><br>
+<img src="{% link /images/week05/05-3/Monophonic_Signal.png %}" alt="3" style="zoom:40%;" /><br>
 <b>Fig 3</b>: Monophonic Signal
 </center>
 
@@ -42,7 +42,7 @@ where $\Omega = \lbrace 1, 2, 3, \cdots \rbrace \subset \mathbb{N}^1$ (since thi
 For the 1D convolution, we can just compute the scalar product, kernel by kernel (see Fig 4).
 
 <center>
-<img src="/images/week05/05-3/Layer_by_layer_scalar_product.png" alt="4" style="zoom:40%;" /><br>
+<img src="{% link /images/week05/05-3/Layer_by_layer_scalar_product.png %}" alt="4" style="zoom:40%;" /><br>
 <b>Fig 4</b>: Layer-by-layer Scalar Product of 1D Convolution
 </center>
 
@@ -114,7 +114,7 @@ In this section we're going to ask torch to check all the computation over the t
 - Calculate the mean of $\boldsymbol{z}$.
 
 <center>
-<img src="/images/week05/05-3/Flow_Chart.png" alt="5" style="zoom:60%;" /><br>
+<img src="{% link /images/week05/05-3/Flow_Chart.png %}" alt="5" style="zoom:60%;" /><br>
 <b>Fig 5</b>: Flow Chart of the Auto-gradient Example
 </center>
 

--- a/docs/zh/week01/01-3.md
+++ b/docs/zh/week01/01-3.md
@@ -28,7 +28,7 @@ translation-date: 2 Mar 2020
 
 我们的视觉化展现的是由五个股组成的螺旋，每个股对应不同颜色。这些点在一个二维平面中，可以用元组来代表；这些颜色代表第三个维度，或者当作是各点的类别。接着我们可以用一个网路来分开不同颜色的点。
 
-| <center><img src="/images/week01/01-3/Spiral1.png" width="200px"/></center> | <center><img src="/images/week01/01-3/Spiral2.png" width="200px"/></center> |
+| <center><img src="{% link /images/week01/01-3/Spiral1.png %}" width="200px"/></center> | <center><img src="{% link /images/week01/01-3/Spiral2.png %}" width="200px"/></center> |
 |                 (a) 输入各点，通过网路前                  |                 (b) 输出各点，通过网路后                  |
 
 <center> 图 1: 五色的螺旋 </center>
@@ -38,7 +38,7 @@ translation-date: 2 Mar 2020
 ### 网路结构
 
 <center>
-<img src="/images/week01/01-3/Network.png" style="zoom: 40%; background-color:#DCDCDC;" /><br>
+<img src="{% link /images/week01/01-3/Network.png %}" style="zoom: 40%; background-color:#DCDCDC;" /><br>
 图 2: 网路结构
 </center>
 
@@ -81,7 +81,7 @@ $$
 
 这里我们用 Numpy 来产生这些矩阵；但我们也可以用 PyTorch 的`nn.Linear` 类别（设定`bias = False`）来建立线性变换。
 
-| ![](/images/week01/01-3/initial_scatter_lab1.png) | ![](/images/week01/01-3/matrix_multiplication_lab1.png) | ![](/images/week01/01-3/matrix_multiplication_lab1_2.png) |
+| ![]({% link /images/week01/01-3/initial_scatter_lab1.png %}) | ![]({% link /images/week01/01-3/matrix_multiplication_lab1.png %}) | ![]({% link /images/week01/01-3/matrix_multiplication_lab1_2.png %}) |
 |         (a) 原来的点           |   (b) $s_1$ = 1.540, $s_2$ = 0.304  |   (c) $s_1$ = 0.464, $s_2$ = 0.017    |
 
 <center> 图 3:  随机矩阵所代表的线性变换 </center>
@@ -96,13 +96,13 @@ $$
 请回忆 $\tanh(\cdot)$ 的图形（参考图 4）
 
 <center>
-<img src="/images/week01/01-3/tanh_lab1.png" width="250px" /><br>
+<img src="{% link /images/week01/01-3/tanh_lab1.png %}" width="250px" /><br>
 图 4：非线性函数－－hyperbolic tangent
 </center>
 
 这个非线性的功能是将各点限制在 $-1$ 和 $+1$ 之间，形成一个方形。当方程式 (2) 中 $s$ 的值增加，愈来愈多的点会被推到方形的边上，我们可以在图 5 看到。藉由把更多的点推到边缘，我们把这些点更加的扩展开，能够接着来分类它们。
 
-| <img src="/images/week01/01-3/matrix_multiplication_with_nonlinearity_s=1_lab1.png" width="200px" /> | <img src="/images/week01/01-3/matrix_multiplication_with_nonlinearity_s=5_lab1.png" width="200px" /> |
+| <img src="{% link /images/week01/01-3/matrix_multiplication_with_nonlinearity_s=1_lab1.png %}" width="200px" /> | <img src="{% link /images/week01/01-3/matrix_multiplication_with_nonlinearity_s=5_lab1.png %}" width="200px" /> |
 |                 (a) $s=1$ 时的非线性                 |                 (b) $s=5$ 时的非线性                  |
 
 <center> 图 5:   非线性变换 </center>
@@ -113,6 +113,6 @@ $$
 最后，就让我们来视觉化一个单纯、未训练的神经网路所进行的变换。这个网路包含一个线性层－－进行仿射变换－－一个 tanh 的非线性，以及另一个线性层。仔细看看图 6 中的变换，我们发现它不同于先前看见的线性和非线性变换。之后我们会看到如何让神经网路所进行的变换完成分类的目标。
 
 <center>
-<img src="/images/week01/01-3/untrained_nn_transformation_lab1.png" width="200px" /><br>
+<img src="{% link /images/week01/01-3/untrained_nn_transformation_lab1.png %}" width="200px" /><br>
 图 6:  未训练的神经网路所进行的变换
 </center>


### PR DESCRIPTION
It turns out in Jekyll, you should use the link tag {% link path/to/file %} to generate
proper permalinks.

Here's the regex:

```
for f in $(fd '.md'); do sd '([^"(]*.png)' '{% link $1 %}' "$f"; done
```