### PR TITLE
Change terms and symbols in "Training data"

### DIFF
--- a/docs/en/week02/02-3.md
+++ b/docs/en/week02/02-3.md
@@ -63,10 +63,10 @@ Last week, we saw that a newly initialised neural network transforms its input i
 <b>Fig. 2</b> Training data
 </center>
 
-* Vector $\boldsymbol c$  and matrix $\boldsymbol Y$ both represent class labels for each of the $$\mathbf m$$ data points. In the example above, there are $$3$$ distinct classes.
+* Vector $\boldsymbol{c}$  and matrix $\boldsymbol{Y}$ both represent class labels for each of the $m$ data points. In the example above, there are $3$ distinct classes.
 
-  * $c_i \in \{1, 2, ..., K\}$, and $\boldsymbol c \in \R^{m \times 1}$. **However, it is not true that** $$\boldsymbol Y \in \R^{m \times 1}$$, i.e. we do not use $$\mathbf c$$ as training data. If we use distinct numeric class labels  $ c_i \in \{1, 2, ..., K\}$, the network may infer an order within the classes that isn't representative of the data distribution.
-  * To bypass this issue, we use **one-hot encoding**. For each data point, a vector of dimension $$K$$ is created, with the $$i$$-th element of the $\boldsymbol y^{(i)} $ vector set to $\mathbf 1$, where $i \in \{1, 2, ..., K\}$​ is the class label for that data point (see **Fig. 3** below).
+  * $c_i \in \lbrace 1, 2, \cdots, K \rbrace$, and $\vect{c} \in \R^m$. However, we may not use $$\vect{c}$$ as training data. If we use distinct numeric class labels  $c_i \in \lbrace 1, 2, \cdots, K \rbrace$, the network may infer an order within the classes that isn't representative of the data distribution.
+  * To bypass this issue, we use a **one-hot encoding**. For each label $c_i$, a $K$ dimensional zero-vector $\vect{y}^{(i)}$ is created, which has the $c_i$-th element set to $1$ (see **Fig. 3** below).
 
 <center>
 <img src="{{site.baseurl}}/images/week02/02-3/one-hot.png" width="250px" /><br>

--- a/docs/en/week02/02-3.md
+++ b/docs/en/week02/02-3.md
@@ -63,10 +63,10 @@ Last week, we saw that a newly initialised neural network transforms its input i
 <b>Fig. 2</b> Training data
 </center>
 
-* $\boldsymbol c$  and $\boldsymbol Y$ are both vectors that represent class labels for each of the $$\mathbf m$$ data points. In the example above, there are $$3$$ distinct classes.
+* Vector $\boldsymbol c$  and matrix $\boldsymbol Y$ both represent class labels for each of the $$\mathbf m$$ data points. In the example above, there are $$3$$ distinct classes.
 
-  * $c_i \in \{1, 2, ..., K\}$, and $\boldsymbol c \in \R^{m \times 1}$. **However, it is not true that** $$\mathbf Y \in \R^{m \times 1}$$, i.e. we do not use $$\mathbf c$$ as training data. If we use distinct numeric class labels  $ c_i \in \{1, 2, ..., K\}$, the network may infer an order within the classes that isn't representative of the data distribution.
-  * To bypass this issue, we use **one-hot encoding**. For each data point, a vector of dimension $$K$$ is created, with the $$i$$-th element of the $\boldsymbol Y $ vector set to $\mathbf 1$, where $i \in \{1, 2, ..., K\}$​ is the class label for that data point (see **Fig. 3** below).
+  * $c_i \in \{1, 2, ..., K\}$, and $\boldsymbol c \in \R^{m \times 1}$. **However, it is not true that** $$\boldsymbol Y \in \R^{m \times 1}$$, i.e. we do not use $$\mathbf c$$ as training data. If we use distinct numeric class labels  $ c_i \in \{1, 2, ..., K\}$, the network may infer an order within the classes that isn't representative of the data distribution.
+  * To bypass this issue, we use **one-hot encoding**. For each data point, a vector of dimension $$K$$ is created, with the $$i$$-th element of the $\boldsymbol y^{(i)} $ vector set to $\mathbf 1$, where $i \in \{1, 2, ..., K\}$​ is the class label for that data point (see **Fig. 3** below).
 
 <center>
 <img src="{{site.baseurl}}/images/week02/02-3/one-hot.png" width="250px" /><br>


### PR DESCRIPTION
I find the use of symbols and terms confusing in the section.
1. "* $\boldsymbol c$  and $\boldsymbol Y$ are both vectors that represent class labels for each of the $$\mathbf m$$ data points. In the example above, there are $$3$$ distinct classes." -- I think Y should be a matrix instead of a vector.
2. "**However, it is not true that** $$\mathbf Y \in \R^{m \times 1}$$" -- Here, Y refers to the same matrix above. IMO, it should have the same typeface `\boldsymbol`.
3. "with the $$i$$-th element of the $\boldsymbol Y $ vector set to $\mathbf 1$" -- Y is used again but as a vector, I think it should be `$\boldsymbol y^{(i)} $` according to the figure.