### PR TITLE
Fixing vert bar latex error

### DIFF
--- a/docs/en/week05/05-2.md
+++ b/docs/en/week05/05-2.md
@@ -193,7 +193,7 @@ Another condition is that we need to have *sparsity* in our image, where by spar
 Compressed sensing is based on the theory of optimization. The way we can get this reconstruction is by solving a mini-optimization problem which has an additional regularization term:
 
 $$
-\hat{x} = \arg\min_x \frac{1}{2} || M (\mathscr{F}(x)) - y||^2 + \lambda TV(x)
+\hat{x} = \arg\min_x \frac{1}{2} \Vert M (\mathscr{F}(x)) - y \Vert^2 + \lambda TV(x)
 $$
 
 where $M$ is the mask function that zeros out non-sampled entries, $\mathscr{F}$ is the Fourier transform, $y$ is the observed Fourier-domain data, $\lambda$ is the regularization penalty strength, and $V$ is the regularization function.

--- a/docs/en/week05/05-2.md
+++ b/docs/en/week05/05-2.md
@@ -193,7 +193,7 @@ Another condition is that we need to have *sparsity* in our image, where by spar
 Compressed sensing is based on the theory of optimization. The way we can get this reconstruction is by solving a mini-optimization problem which has an additional regularization term:
 
 $$
-\hat{x} = \arg\min_x \frac{1}{2} |Vert M (\mathscr{F}(x)) - y|Vert^2 + \lambda TV(x)
+\hat{x} = \arg\min_x \frac{1}{2} || M (\mathscr{F}(x)) - y||^2 + \lambda TV(x)
 $$
 
 where $M$ is the mask function that zeros out non-sampled entries, $\mathscr{F}$ is the Fourier transform, $y$ is the observed Fourier-domain data, $\lambda$ is the regularization penalty strength, and $V$ is the regularization function.


### PR DESCRIPTION
The website was displaying "Vert" instead of || due to a latex error which should be fixed now.