### PR TITLE
Fix macros for display mode

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -32,7 +32,8 @@ markdown:            kramdown
 # To use hljs, disable the default highlighter
 kramdown:
   syntax_highlighter_opts:
-    disable : true
+    disable: true
+  math_engine: null
 
 exclude:
   - jekyllbook


### PR DESCRIPTION
The bug is that the default Markdown parser actually does some
pre-processing of the display mode _only_ in a weird way that
made macros not apply. By disabling that, it behaves as expected.