### PR TITLE
Fix typo in Week 5 documentation

### DIFF
--- a/docs/en/week05/05.md
+++ b/docs/en/week05/05.md
@@ -5,7 +5,7 @@ title: Week 5
 
 ## Lecture part A
 
-We begin by introducing Gradient Descent. We discuss the intuition and also talk about how step sizes play an important role in reaching the solution. Then we move on to SGD and its performance in comparison to Full Batch GD. Finally we talk about Momentum Updates, specifically the two update rules, the intuition behind momentum and its effect on covergence.
+We begin by introducing Gradient Descent. We discuss the intuition and also talk about how step sizes play an important role in reaching the solution. Then we move on to SGD and its performance in comparison to Full Batch GD. Finally we talk about Momentum Updates, specifically the two update rules, the intuition behind momentum and its effect on convergence.
 
 
 ## Lecture part B


### PR DESCRIPTION
The word `covergence` seems like a typo. Is it `convergence`?