### PR TITLE
11.3 Scribe - grammar and formatting issues fixed

### DIFF
--- a/docs/en/week11/11-3.md
+++ b/docs/en/week11/11-3.md
@@ -136,7 +136,7 @@ Now, let us look at the inference - How do we drive?
 
 
 
-We sample the low-dimensional latent variable $z_t$ from the prior by enforcing the encoder to shoot it towards this distribution. After getting the prediction $\hat{s}_{t+1}$, we put it back (in an auto-regressive step) and get the next prediction $\hat{s}_{t+2}$ and keep feeding the network this way.
+We sample the low-dimensional latent variable $z_t$ from the prior by enforcing the encoder to shoot it towards this distribution. After getting the prediction $\hat s_{t+1}$, we put it back (in an auto-regressive step) and get the next prediction $\hat s_{t+2}$ and keep feeding the network this way.
 
 <center>
 <img src="{{site.baseurl}}/images/week11/11-3/figure13.png" style="zoom: 22%; background-color:#DCDCDC;" /><br>
@@ -189,7 +189,7 @@ The problem is not a memory leak but an information leak. We fix this problem by
 
 <center>
 <img src="{{site.baseurl}}/images/week11/11-3/figure18.png" style="zoom: 40%; background-color:#DCDCDC;" /><br>
-<b>Figure 18:</b> Fix - Latent Dropout
+<b>Figure 18:</b> Performance with latent dropout
 </center>
 
 In the last two images on the right-hand side, we see two different sets of latent variables having a real sequence of actions and these networks have been trained with the latent dropout trick. We can now see that the rotation is now encoded by the action and no longer by the latent variables.
@@ -199,9 +199,9 @@ In the last two images on the right-hand side, we see two different sets of late
 
 In the previous sections, we saw how we can obtain a world model by simulating real world experiences.  In this section, we will use this world model to train our agent.  Our goal is to learn the policy to take an action given the history of previous states.  Given a state $s_t$ (velocity, position & context images), the agent takes an action $a_t$ (acceleration, brake & steering), the world model outputs a next state and cost associated with that $(s_t, a_t)$ pair which is a combination of proximity cost and lane cost.  
 
-\begin{equation}
+$$
 c_{task} = c_{proximity} + \lambda_l c_{lane} 
-\end{equation}
+$$
 
 As discussed in the previous section, to avoid hazy predictions, we need to sample latent variable $z_t$ from the encoder module of the future state $s_{t+1}$ or from prior distribution $P(z)$.  The world model gets previous states $s_{1:t}$, action taken by our agent and latent variable $z_t$ to predict the next state $\hat s_{t+1}$ and the cost.  This constitutes one module that is replicated multiple times (Figure 19) to give us final prediction and loss to optimize.
 
@@ -225,9 +225,9 @@ How can we address this issue? Can we try imitating other vehicles to improve ou
 
 How do we imitate the experts here? We want the prediction of our model after taking a particular action from a state to be as close as possible to the actual future. This acts as an expert regularizer for our training. Our cost function now includes both the task specific cost(proximity cost and lane cost) and this expert regularizer term. Now as we are also calculating the loss with respect to the actual future, we have to remove the latent variable from the model because the latent variable gives us a specific prediction, but this setting works better if we just work with the average prediction. 
 
-\begin{equation}
+$$
 loss = c_{task} + \lambda u_{expert} 
-\end{equation}
+$$
 
 <center>
 <img src="{{site.baseurl}}/images/week11/11-3/figure21.png" style="zoom: 40%; background-color:#DCDCDC;" /><br>
@@ -263,9 +263,9 @@ Coming back to our discussion, we observe that learning a policy using only obse
 
 To address this, we propose an additional cost which measures the uncertainty of the dynamics model about its own predictions. This can be calculated by passing the same input and action through several different dropout masks, and computing the variance across the different outputs.  This encourages the policy network to only produce actions for which the forward model is confident.  
 
-\begin{equation}
+$$
 loss = c_{task} + \lambda c_{uncertainty} 
-\end{equation}
+$$
 
 <center>
 <img src="{{site.baseurl}}/images/week11/11-3/figure24.png" style="zoom: 40%; background-color:#DCDCDC;" /><br>
@@ -287,5 +287,5 @@ Figure 26 shows how well our agent learned to drive in dense traffic.  Yellow ca
 
 <center>
 <img src="{{site.baseurl}}/images/week11/11-3/figure26.gif" style="zoom: 60%; background-color:#DCDCDC;" /><br>
-<b>Figure 26:</b> Leared policy based on uncertainty regularizer
+<b>Figure 26:</b> Performance of model with uncertainty regularizer
 </center>


### PR DESCRIPTION
- Equations were not rendering on the website correctly. Changed the latex formatting.

- Changed the captions of the figures.

- Handled grammar related issues.