### PR TITLE
FIX idx otherwise acc>1

### DIFF
--- a/15-transformer.ipynb
+++ b/15-transformer.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "source": [
     "# Transformers\n",
     "To understand anything that's going on below, check first the slides / video lesson."
@@ -11,7 +13,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "import torch \n",
@@ -23,7 +27,9 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
@@ -32,7 +38,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "source": [
     "## Multi head attention"
    ]
@@ -40,7 +48,9 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "class MultiHeadAttention(nn.Module):\n",
@@ -118,7 +128,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "source": [
     "### Some sanity checks:"
    ]
@@ -126,7 +138,9 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "temp_mha = MultiHeadAttention(d_model=512, num_heads=8, p=0)\n",
@@ -138,7 +152,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "source": [
     "To check our self attention works - if the query matches with one of the key values, it should have all the attention focused there, with the value returned as the value at that index"
    ]
@@ -147,6 +163,7 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
+    "Collapsed": "false",
     "scrolled": true
    },
    "outputs": [
@@ -182,7 +199,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "source": [
     "Great! We can see that it focuses on the second key and returns the second value. \n",
     "\n",
@@ -192,7 +211,9 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -210,7 +231,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "source": [
     "We see that it focuses equally on the third and fourth key and returns the average of their values.\n",
     "\n",
@@ -220,7 +243,9 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -244,14 +269,18 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "source": [
     "## 1D convolution with `kernel_size = 1`"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "source": [
     "This is basically an MLP with one hidden layer and ReLU activation applied to each and every element in the set."
    ]
@@ -259,7 +288,9 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "class CNN(nn.Module):\n",
@@ -278,14 +309,18 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "source": [
     "## Transformer encoder"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "source": [
     "Now we have all components for our Transformer Encoder block shown below!!!!"
    ]
@@ -293,7 +328,9 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "class EncoderLayer(nn.Module):\n",
@@ -325,7 +362,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "source": [
     "### Encoder \n",
     "#### Blocks of N Encoder Layers + Positional encoding + Input embedding"
@@ -333,7 +372,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "source": [
     "Self attention by itself does not have any recurrence or convolutions so to make it sensitive to position we must provide additional positional encodings. These are calculated as follows:\n",
     "\n",
@@ -346,7 +387,9 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "def create_sinusoidal_embeddings(nb_p, dim, E):\n",
@@ -395,7 +438,9 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "class Encoder(nn.Module):\n",
@@ -424,7 +469,9 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "import torchtext.data as data\n",
@@ -434,7 +481,9 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -460,7 +509,9 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -482,7 +533,9 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "num_words = 50_000\n",
@@ -494,7 +547,9 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "batch_size = 164\n",
@@ -505,7 +560,9 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "class TransformerClassifier(nn.Module):\n",
@@ -527,7 +584,9 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [
     {
      "data": {
@@ -605,7 +664,9 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "optimizer = torch.optim.AdamW(model.parameters(), lr=0.001)\n",
@@ -616,7 +677,9 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "def train(train_loader, valid_loader):\n",
@@ -644,8 +707,8 @@
     "                        \n",
     "            train_acc += (out.argmax(1) == y).cpu().numpy().mean()\n",
     "        \n",
-    "        print(f\"Training loss at epoch {epoch} is {losses/idx}\")\n",
-    "        print(f\"Training accuracy: {train_acc/idx}\")\n",
+    "        print(f\"Training loss at epoch {epoch} is {losses/(idx+1)}\")\n",
+    "        print(f\"Training accuracy: {train_acc/(idx+1)}\")\n",
     "        print('Evaluating on validation:')\n",
     "        evaluate(valid_loader)"
    ]
@@ -653,7 +716,9 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "def evaluate(data_loader):\n",
@@ -667,14 +732,14 @@
     "        out = model(x)\n",
     "        acc += (out.argmax(1) == y).cpu().numpy().mean()\n",
     "\n",
-    "    print(f\"Eval accuracy: {acc/idx}\")"
+    "    print(f\"Eval accuracy: {acc/(idx+1)}\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 33,
    "metadata": {
-    "scrolled": false
+    "Collapsed": "false"
    },
    "outputs": [
     {
@@ -731,7 +796,9 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "metadata": {},
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -748,7 +815,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 [conda env:pDL]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -762,9 +829,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/15-transformer.ipynb
+++ b/15-transformer.ipynb
@@ -2,9 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "source": [
     "# Transformers\n",
     "To understand anything that's going on below, check first the slides / video lesson."
@@ -13,9 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import torch \n",
@@ -27,9 +23,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
@@ -38,9 +32,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "source": [
     "## Multi head attention"
    ]
@@ -48,9 +40,7 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class MultiHeadAttention(nn.Module):\n",
@@ -128,9 +118,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "source": [
     "### Some sanity checks:"
    ]
@@ -138,9 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "temp_mha = MultiHeadAttention(d_model=512, num_heads=8, p=0)\n",
@@ -152,9 +138,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "source": [
     "To check our self attention works - if the query matches with one of the key values, it should have all the attention focused there, with the value returned as the value at that index"
    ]
@@ -163,7 +147,6 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
-    "Collapsed": "false",
     "scrolled": true
    },
    "outputs": [
@@ -199,9 +182,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "source": [
     "Great! We can see that it focuses on the second key and returns the second value. \n",
     "\n",
@@ -211,9 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -231,9 +210,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "source": [
     "We see that it focuses equally on the third and fourth key and returns the average of their values.\n",
     "\n",
@@ -243,9 +220,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -269,18 +244,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "source": [
     "## 1D convolution with `kernel_size = 1`"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "source": [
     "This is basically an MLP with one hidden layer and ReLU activation applied to each and every element in the set."
    ]
@@ -288,9 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class CNN(nn.Module):\n",
@@ -309,18 +278,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "source": [
     "## Transformer encoder"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "source": [
     "Now we have all components for our Transformer Encoder block shown below!!!!"
    ]
@@ -328,9 +293,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class EncoderLayer(nn.Module):\n",
@@ -362,9 +325,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "source": [
     "### Encoder \n",
     "#### Blocks of N Encoder Layers + Positional encoding + Input embedding"
@@ -372,9 +333,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "source": [
     "Self attention by itself does not have any recurrence or convolutions so to make it sensitive to position we must provide additional positional encodings. These are calculated as follows:\n",
     "\n",
@@ -387,9 +346,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def create_sinusoidal_embeddings(nb_p, dim, E):\n",
@@ -438,9 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class Encoder(nn.Module):\n",
@@ -469,9 +424,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import torchtext.data as data\n",
@@ -481,9 +434,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -509,9 +460,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -533,9 +482,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "num_words = 50_000\n",
@@ -547,9 +494,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "batch_size = 164\n",
@@ -560,9 +505,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class TransformerClassifier(nn.Module):\n",
@@ -584,9 +527,7 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -664,9 +605,7 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "optimizer = torch.optim.AdamW(model.parameters(), lr=0.001)\n",
@@ -677,9 +616,7 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def train(train_loader, valid_loader):\n",
@@ -716,9 +653,7 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def evaluate(data_loader):\n",
@@ -739,7 +674,7 @@
    "cell_type": "code",
    "execution_count": 33,
    "metadata": {
-    "Collapsed": "false"
+    "scrolled": false
    },
    "outputs": [
     {
@@ -796,9 +731,7 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "metadata": {
-    "Collapsed": "false"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -815,7 +748,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 [conda env:pDL]",
    "language": "python",
    "name": "python3"
   },
@@ -829,9 +762,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 2
 }

--- a/15-transformer.ipynb
+++ b/15-transformer.ipynb
@@ -623,11 +623,12 @@
     "    \n",
     "    for epoch in range(epochs):\n",
     "        train_iterator, valid_iterator = iter(train_loader), iter(valid_loader)\n",
+    "        nb_batches_train = len(train_loader)\n",
     "        train_acc = 0\n",
     "        model.train()\n",
     "        losses = 0.0\n",
     "\n",
-    "        for idx, batch in enumerate(train_iterator):\n",
+    "        for batch in train_iterator:\n",
     "            x = batch.text.to(device)\n",
     "            y = batch.label.to(device)\n",
     "            \n",
@@ -644,8 +645,8 @@
     "                        \n",
     "            train_acc += (out.argmax(1) == y).cpu().numpy().mean()\n",
     "        \n",
-    "        print(f\"Training loss at epoch {epoch} is {losses/(idx+1)}\")\n",
-    "        print(f\"Training accuracy: {train_acc/(idx+1)}\")\n",
+    "        print(f\"Training loss at epoch {epoch} is {losses / nb_batches_train}\")\n",
+    "        print(f\"Training accuracy: {train_acc / nb_batches_train}\")\n",
     "        print('Evaluating on validation:')\n",
     "        evaluate(valid_loader)"
    ]
@@ -658,16 +659,17 @@
    "source": [
     "def evaluate(data_loader):\n",
     "    data_iterator = iter(data_loader)\n",
+    "    nb_batches = len(data_loader)\n",
     "    model.eval()\n",
     "    acc = 0 \n",
-    "    for idx, batch in enumerate(data_iterator):\n",
+    "    for batch in data_iterator:\n",
     "        x = batch.text.to(device)\n",
     "        y = batch.label.to(device)\n",
     "                \n",
     "        out = model(x)\n",
     "        acc += (out.argmax(1) == y).cpu().numpy().mean()\n",
     "\n",
-    "    print(f\"Eval accuracy: {acc/(idx+1)}\")"
+    "    print(f\"Eval accuracy: {acc / nb_batches}\")"
    ]
   },
   {


### PR DESCRIPTION
Just a quick fix on `idx` when playing around, otherwise the `acc` can be >1 (noticed this when overfitting the same small batch)