### PR TITLE
Fixing content issue in line55 of [EN] 14-2.md

### DIFF
--- a/docs/en/week14/14-2.md
+++ b/docs/en/week14/14-2.md
@@ -52,7 +52,7 @@ The perceptron loss seen in the table above does not have a margin, and thus the
 
 Q: How may hinge be better than NLL loss?
 
-A: Hinge is better than NLL becuase hinge will try to push the difference between the correct answer and other answers to infinity, whereas hinge only wants to make it larger than some value (the margin m). 
+A: Hinge is better than NLL becuase NLL will try to push the difference between the correct answer and other answers to infinity, whereas hinge only wants to make it larger than some value (the margin m). 
 
 ### DEFINITION:
 


### PR DESCRIPTION

Q: How may hinge be better than NLL loss?

A: Hinge is better than NLL becuase **NLL** will try to push the difference between the correct answer and other answers to infinity, whereas hinge only wants to make it larger than some value (the margin m).