### PR TITLE
[EN] Fixed formula in English documents for chapter 13-3, Notation section.

### DIFF
--- a/docs/en/week13/13-3.md
+++ b/docs/en/week13/13-3.md
@@ -31,7 +31,7 @@ Unlike a sequence, it does not have an order.
 </center>
 
 In Figure 1, vertex $v$ is comprised of two vectors: input $\boldsymbol{x}$ and its hidden representation $\boldsymbol{h}$.
-We also have multiple vertices $v_{j}$, which is comprised of $\boldsymbol{x_{j}}$ and $\boldsymbol{h_{j}}$.
+We also have multiple vertices $v_{j}$, which is comprised of $\boldsymbol{x}\_j$ and $\boldsymbol{h}\_j$.
 In this graph, vertices are connected with directed edges.
 
 We represent these directed edges with adjacency vector $\boldsymbol{a}$, where each element $\alpha_{j}$ is set to $1$ if there is a directed edge from $v_{j}$ to $v$.

--- a/docs/en/week13/13-3.md
+++ b/docs/en/week13/13-3.md
@@ -31,7 +31,7 @@ Unlike a sequence, it does not have an order.
 </center>
 
 In Figure 1, vertex $v$ is comprised of two vectors: input $\boldsymbol{x}$ and its hidden representation $\boldsymbol{h}$.
-We also have multiple vertices $v_{j}$, which is comprised of $\boldsymbol{x}_{j}$ and $\boldsymbol{h}_{j}$.
+We also have multiple vertices $v_{j}$, which is comprised of $\boldsymbol{x_{j}}$ and $\boldsymbol{h_{j}}$.
 In this graph, vertices are connected with directed edges.
 
 We represent these directed edges with adjacency vector $\boldsymbol{a}$, where each element $\alpha_{j}$ is set to $1$ if there is a directed edge from $v_{j}$ to $v$.


### PR DESCRIPTION
The formula wasn't correctly rendered:
Before fix:
<img width="785" alt="Screen Shot 2020-09-19 at 11 16 45" src="https://user-images.githubusercontent.com/11987768/93657196-67509380-fa6b-11ea-9dce-4ccde2cea261.png">
After fix:
<img width="746" alt="Screen Shot 2020-09-19 at 11 17 28" src="https://user-images.githubusercontent.com/11987768/93657194-64ee3980-fa6b-11ea-81a7-c6704f98df3e.png">

I haven't checked the rest of the translations, but since the English one wasn't fixed maybe the rest do have this problem as well.

@Atcold 




