### PR TITLE
[TR] 13-3: propagating fix to English latex

### DIFF
--- a/docs/tr/week13/13-3.md
+++ b/docs/tr/week13/13-3.md
@@ -44,7 +44,7 @@ Unlike a sequence, it does not have an order.
 <b>Fig. 1</b>: Graph Convolutional Network
 </center>
 In Figure 1, vertex $v$ is comprised of two vectors: input $\boldsymbol{x}$ and its hidden representation $\boldsymbol{h}$.
-We also have multiple vertices $v_{j}$, which is comprised of $\boldsymbol{x}_{j}$ and $\boldsymbol{h}_{j}$.
+We also have multiple vertices $v_{j}$, which is comprised of $\boldsymbol{x}\_j$ and $\boldsymbol{h}\_j$.
 In this graph, vertices are connected with directed edges.
 We represent these directed edges with adjacency vector $\boldsymbol{a}$, where each element $\alpha_{j}$ is set to $1$ if there is a directed edge from $v_{j}$ to $v$.
 $$
@@ -82,7 +82,7 @@ where $\vect{D} = \text{diag}(d_{i})$.
 </center>
 
 Şekil 1'de, düğüm *(vertex)* $v$ iki vektörden oluşur: girdi $\boldsymbol{x}$ ve saklı gösterimi $\boldsymbol{h}$.
-Çizgemizde $v_{j}$, which is comprised of $\boldsymbol{x}_{j}$ ,\text{and} $\boldsymbol{h}_{j}$. Üstteki çizgede düğümler, yönlü ayrıtlar *(directed edges)* ile birbirlerine bağlıdır.
+Çizgemizde $v_{j}$, which is comprised of $\boldsymbol{x}\_j$ and $\boldsymbol{h}\_j$. Üstteki çizgede düğümler, yönlü ayrıtlar *(directed edges)* ile birbirlerine bağlıdır.
 
 Yönlü ayrıtlar, komşuluk vektörü $\boldsymbol{a}$ ile ifade edilir, bu vektörün elemanı $\alpha_{j}$  eğer $v_{j}$'den $v$'ye gidilebiliyorsa 1 değerini alır.
 


### PR DESCRIPTION
Propagating the changes made [here](https://github.com/Atcold/pytorch-Deep-Learning/pull/576)

The translation is wrong (there is English text) nearby my changes by the way:
Çizgemizde $v_{j}$, **which is comprised of** $\boldsymbol{x}\_j$ and $\boldsymbol{h}\_j$.