### PR TITLE
Add badges to launch repo in Colab & Deepnote

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Deep Learning (with PyTorch) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Atcold/pytorch-Deep-Learning/master)
+# Deep Learning (with PyTorch) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Atcold/pytorch-Deep-Learning/master) [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Atcold/pytorch-Deep-Learning/blob/master/) [![Deepnote](https://deepnote.com/buttons/launch-in-deepnote-small.svg)](https://www.deepnote.com/launch?template=data-science&url=https://github.com/Atcold/pytorch-Deep-Learning/blob/master/00-logic_neuron_programming.ipynb)
 
 This notebook repository now has a [companion website](https://atcold.github.io/pytorch-Deep-Learning/), where all the course material can be found in video and textual format.
 


### PR DESCRIPTION
As seen on Aurélien Geron's Hands-On ML repo (https://github.com/ageron/handson-ml2), I have added links to launch the repo in Google Colab and Deepnote