### PR TITLE
[PT] Portuguese translation of the second week of the course

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -724,5 +724,10 @@ bn:
 pt:
   title: 'Aprendizagem Profunda'
   chapters:
+    - path: pt/week01/01-1.md
+    - path: pt/week02/02.md
       sections:
-        - path: pt/week01/01-1.md
+        - path: pt/week02/02-1.md
+        - path: pt/week02/02-2.md
+        - path: pt/week02/02-3.md
+

--- a/docs/pt/week02/02-1.md
+++ b/docs/pt/week02/02-1.md
@@ -1,0 +1,675 @@
+---
+lang: pt
+lang-ref: ch.02-1
+lecturer: Yann LeCun
+title: Introdução ao gradiente descendente e algoritmo de retropopagação
+authors: Amartya Prasad, Dongning Fang, Yuxin Tang, Sahana Upadhya
+date: 3 Feb 2020
+translation-date: 28 Fev 2021
+translator: Lenin Cristi
+---
+
+<!-- ## [Gradient Descent optimization algorithm](https://www.youtube.com/watch?v=d9vdh3b787Y&t=29s)
+
+### Parametrised models
+
+$$
+\bar{y} = G(x,w)
+$$
+
+Parametrised models are simply functions that depend on inputs and trainable parameters. There is no fundamental difference between the two, except that trainable parameters are shared across training samples whereas the input varies from sample to sample. In most deep learning frameworks, parameters are implicit, that is, they aren't passed when the function is called. They are 'saved inside the function', so to speak, at least in the object-oriented versions of models.
+
+The parametrised model (function) takes in an input, has a parameter vector and produces an output. In supervised learning, this output goes into the cost function ($C(y,\bar{y}$)), which compares the true output (${y}$) with the model output ($\bar{y}$). The computation graph for this model is shown in Figure 1.
+
+| <center><img src="{{site.baseurl}}/images/week02/02-1/Figure1.jpg" alt="Figure1" style="zoom: 33%;" /></center> |
+| <center>Figure 1: Computation Graph representation for a Parametrised Model </center>|
+
+Examples of parametrised functions -
+
+- Linear Model - Weighted Sum of Components of the Input Vector :
+
+  $$
+  \bar{y} = \sum_i w_i x_i, C(y,\bar{y}) = \Vert y - \bar{y}\Vert^2
+  $$
+
+- Nearest Neighbour - There is an input $\vect{x}$ and a weight matrix $\matr{W}$ with each row of the matrix indexed by $k$. The output is the value of $k$ that corresponds to the row of $\matr{W}$ that is closest to $\vect{x}$:
+
+  $$
+  \bar{y} = \underset{k}{\arg\min} \Vert x - w_{k,.} \Vert^2
+  $$
+
+  Parameterized models could also involve complicated functions. -->
+
+## [Algoritmo de otimização de gradiente descendente](https://www.youtube.com/watch?v=d9vdh3b787Y&t=29s)
+
+### Modelos parametrizados
+
+$$
+\bar{y} = G(x,w)
+$$
+
+Os modelos parametrizados são simplesmente funções que dependem de entradas e parâmetros treináveis. Não há diferença fundamental entre os dois exceto que os parâmetros treináveis são compartilhados entre as amostras de treinamento enquanto que as entradas variam de amostra para amostra. Na maioria dos frameworks de aprendizado profundo, os parâmetros são implícitos, ou seja, eles não são passados quando a função é chamada. Eles são 'salvos dentro da função' por assim dizer, ao menos nas versões orientadas a objetos desses modelos.
+
+O modelo parametrizado (função) recebe uma entrada, um vetor de parâmetros e produz uma saída. Na aprendizagem supervisionada, essa saída vai para a função de custo ($C(y,\bar{y}$)), que compara a saída verdadeira (${y}$) com a saída do modelo ($\bar{y}$). O gráfico da computação deste modelo é mostrado na Figura 1.
+
+| <center><img src="{{site.baseurl}}/images/week02/02-1/Figure1.jpg" alt="Figura 1" style="zoom: 33%;" /></center> |
+| <center>Figura 1: Representação do gráfico de computação para um modelo parametrizado</center>|
+
+Exemplos de funções parametrizadas -
+
+- Linear - Soma Ponderada dos Componentes do Vetor de Entrada:
+
+  $$
+  \bar{y} = \sum_i w_i x_i, C(y,\bar{y}) = \Vert y - \bar{y}\Vert^2
+  $$
+
+- Vizinho mais próximo - há uma entrada $\vect{x}$ e uma matriz de peso $\matr{W}$ com cada linha da matriz indexada por $k$. A saída é o valor de $k$ que corresponde à linha de $\matr{W}$ que é mais próximo de $\vect{x}$:
+
+  $$
+  \bar{y} = \underset{k}{\arg\min} \Vert x - w_{k,.} \Vert^2
+  $$
+
+  Modelos parametrizados também podem envolver funções complicadas.
+
+<!-- #### Block diagram notations for computation graphs
+
+- Variables (tensor, scalar, continuous, discrete)
+    - <img src="{{site.baseurl}}/images/week02/02-1/x.PNG" alt="x" style="zoom:50%;" /> is an observed input to the system
+    - <img src="{{site.baseurl}}/images/week02/02-1/y.PNG" alt="y" style="zoom:50%;" /> is a computed variable which is produced by a deterministic function
+
+- Deterministic functions
+
+    <img src="{{site.baseurl}}/images/week02/02-1/deterministic_function.PNG" alt="deterministic_function" style="zoom:50%;" />
+
+    - Takes in multiple inputs and can produce multiple outputs
+    - It has an implicit parameter variable (${w}$)
+    - The rounded side indicates the direction in which it is easy to compute. In the above diagram, it is easier to compute ${\bar{y}}$ from ${x}$ than the other way around
+
+- Scalar-valued function
+
+  <img src="{{site.baseurl}}/images/week02/02-1/scalar-valued.PNG" alt="scalar-valued" style="zoom:50%;" />
+
+    - Used to represent cost functions
+    - Has an implicit scalar output
+    - Takes multiple inputs and outputs a single value (usually the distance between the inputs) -->
+
+#### Notações de diagrama de bloco para gráficos de computação
+
+- Variáveis (tensor, escalar, contínua, discreta)
+    - <img src="{{site.baseurl}}/images/week02/02-1/x.PNG" alt="x" style="zoom:50%;" /> é uma entrada observada para o sistema
+    - <img src="{{site.baseurl}}/images/week02/02-1/y.PNG" alt="y" style="zoom:50%;" /> é uma variável computada que é produzida por uma função determinística
+
+- Funções determinísticas
+
+    <img src="{{site.baseurl}}/images/week02/02-1/deterministic_function.PNG" alt="função determinística" style="zoom:50%;" />
+
+    - Aceita várias entradas e pode produzir várias saídas
+    - Tem uma variável de parâmetro implícita (${w}$)
+    - O lado arredondado indica a direção em que é fácil calcular. No diagrama acima, é mais fácil calcular ${\bar{y}}$ de ${x}$ do que o contrário
+
+- Função com valor escalar
+
+  <img src="{{site.baseurl}}/images/week02/02-1/scalar-valued.PNG" alt="com valor escalar" style="zoom:50%;" />
+
+    - Usado para representar funções de custo
+    - Tem uma saída escalar implícita
+    - Recebe várias entradas e produz um único valor (normalmente a distância entre as entradas)
+
+<!-- #### Loss functions
+
+Loss function is a function that is minimized during training. There are two types of losses:
+
+1) Per Sample Loss -
+
+$$
+ L(x,y,w) = C(y, G(x,w))
+$$
+
+2) Average Loss -
+
+For any set of Samples
+
+$$S = \lbrace(x[p],y[p]) \mid p \in \lbrace 0, \cdots, P-1 \rbrace \rbrace$$
+
+Average Loss over the Set $S$ is given by:
+
+$$L(S,w) = \frac{1}{P} \sum_{(x,y)} L(x,y,w)$$
+
+| <center><img src="{{site.baseurl}}/images/week02/02-1/Average_Loss.png" alt="Average_Loss" style="zoom:33%;" /></center> |
+|   <center>Figure 2: Computation graph for model with Average Loss    </center>|
+
+In the standard Supervised Learning paradigm, the loss (per sample) is simply the output of the cost function. Machine Learning is mostly about optimizing functions (usually minimizing them). It could also involve finding Nash Equilibria between two functions like with GANs. This is done using Gradient Based Methods, though not necessarily Gradient Descent. -->
+
+#### Funções de perda
+
+A função de perda é uma função que é minimizada durante o treinamento. Existem dois tipos de perdas:
+
+1) Perda por Amostra -
+
+$$
+ L(x,y,w) = C(y, G(x,w))
+$$
+
+2) Perda Média -
+
+Para qualquer conjunto de amostras
+
+$$S = \lbrace(x[p],y[p]) \mid p \in \lbrace 0, \cdots, P-1 \rbrace \rbrace$$
+
+Perda média ao longo do conjunto $S$ É dado por:
+
+$$L(S,w) = \frac{1}{P} \sum_{(x,y)} L(x,y,w)$$
+
+| <center><img src="{{site.baseurl}}/images/week02/02-1/Average_Loss.png" alt="perda Média" style="zoom:33%;" /></center> |
+|   <center>Figura 2: Gráfico de computação para modelo com perda média    </center>|
+
+No paradigma de Aprendizagem Supervisionada padrão, a perda (por amostra) é simplesmente a saída da função de custo. O aprendizado de máquina é principalmente sobre otimização de funções (geralmente as minimizando). Também pode envolver encontrar o Equilíbrio de Nash entre duas funções como em *GANs*. Isso é feito usando Métodos Baseados em Gradiente, embora não necessariamente o Gradiente Descendente.
+
+<!-- ### Gradient descent
+
+A **Gradient Based Method** is a method/algorithm that finds the minima of a function, assuming that one can easily compute the gradient of that function. It assumes that the function is continuous and differentiable almost everywhere (it need not be differentiable everywhere).
+
+**Gradient Descent Intuition** - Imagine being in a mountain in the middle of a foggy night. Since you want to go down to the village and have only limited vision, you look around your immediate vicinity to find the direction of steepest descent and take a step in that direction.
+
+**Different methods of Gradient Descent**
+
+- Full (batch) gradient descent update rule :
+
+  $$
+  w \leftarrow w - \eta \frac{\partial L(S,w)}{\partial w}
+  $$
+
+- For SGD (Stochastic Gradient  Descent), the update rule becomes :
+
+  - Pick a $p \in \lbrace 0, \cdots, P-1 \rbrace$, then update
+
+    $$
+    w \leftarrow w - \eta \frac{\partial L(x[p], y[p],w)}{\partial w}
+    $$
+
+Where ${w}$ represents the parameter to be optimized.
+
+$\eta$ is a constant here but in more sophisticated algorithms, it could be a matrix.
+
+If it is a positive semi-definite matrix, we'll still move downhill but not necessarily in the direction of steepest descent. In fact the direction of steepest descent may not always be the direction we want to move in.
+
+If the function is not differentiable, i.e, it has a hole or is staircase like or flat, where the gradient doesn't give you any information, one has to resort to other methods - called 0-th Order Methods or Gradient-Free Methods. Deep Learning is all about Gradient Based Methods.
+
+However, RL (Reinforcement Learning) involves **Gradient Estimation** without the explicit form for the gradient. An example is a robot learning to ride a bike where the robot falls every now and then. The objective function measures how long the bike stays up without falling. Unfortunately, there is no gradient for the objective function. The robot needs to try different things.
+
+The RL cost function is not differentiable most of the time but the network that computes the output is gradient-based. This is the main difference between supervised learning and reinforcement learning. With the latter, the cost function $C$ is not differentiable. In fact it completely unknown. It just returns an output when inputs are fed to it, like a blackbox. This makes it highly inefficient and is one of the main drawbacks of RL - particularly when the parameter vector is high dimensional (which implies a huge solution space to search in, making it hard to find where to move).
+
+A very popular technique in RL is Actor Critic Methods. A critic method basically consists of a second C module which is a known, trainable module. One is able to train the C module, which is differentiable, to approximate the cost function/reward function. The reward is a negative cost, more like a punishment. That’s a way of making the cost function differentiable, or at least approximating it by a differentiable function so that one can backpropagate. -->
+
+### Gradiente descendente
+
+Um **Método Baseado em Gradiente** é um método/algoritmo que encontra os mínimos de uma função, assumindo que se pode facilmente calcular o gradiente dessa função. Ele assume que a função é contínua e diferenciável em quase todos os intervalos (não precisa ser diferenciável em todos os intervalos).
+
+**Abstração do Gradiente Descendente** - Imagine estar em uma montanha no meio de uma noite de nevoeiro. Já que você quer descer para a aldeia e tem apenas uma visão limitada, você olha ao redor de sua vizinhança imediata para encontrar a direção da descida mais íngreme e dá um passo nessa direção.
+
+**Diferentes métodos de gradiente descendente**
+
+- Regra completa de atualização (em lotes) do gradiente descendente :
+
+  $$
+  w \leftarrow w - \eta \frac{\partial L(S,w)}{\partial w}
+  $$
+
+- Para SGD (Gradiente Descendente Estocástico), a regra de atualização se torna :
+
+  - Escolha um $p \in \lbrace 0, \cdots, P-1 \rbrace$, então atualize
+
+    $$
+    w \leftarrow w - \eta \frac{\partial L(x[p], y[p],w)}{\partial w}
+    $$
+
+Onde ${w}$ representa o parâmetro a ser otimizado.
+
+$\eta$ é uma constante aqui, mas em algoritmos mais sofisticados, pode ser uma matriz.
+
+Se for uma matriz semi-definida positiva, ainda vamos descer a colina, mas não necessariamente na direção da descida mais íngreme. De fato, a direção da descida mais íngreme nem sempre é a direção em que desejamos nos mover.
+
+Se a função não for diferenciável, ou seja, tem um buraco ou é semelhante a uma escada ou plano, onde o gradiente não fornece nenhuma informação, é preciso recorrer a outros métodos - chamados Métodos de Ordem Zero ou Métodos Livres de Gradiente. Aprendizado profundo é sobre métodos baseados em gradiente.
+
+Contudo, *RL* (Aprendizagem por Reforço) envolve **Estimativa de Gradiente** sem a forma explícita do gradiente. Um exemplo é um robô aprendendo a andar de bicicleta, onde o robô cai de vez em quando. A função objetivo mede quanto tempo a bicicleta permanece levantada sem cair. Infelizmente, não há gradiente para a função objetivo. O robô precisa tentar coisas diferentes.
+
+A função de custo da *RL* não é diferenciável na maioria das vezes, mas a rede que calcula a saída é baseada em gradiente. Esta é a principal diferença entre aprendizagem supervisionada e aprendizagem por reforço. Na última, a função de custo $C$ não é diferenciável. Na verdade, é completamente desconhecida. Ela apenas retorna uma saída quando as entradas são a ela fornecidas, como uma caixa preta. Isso a torna altamente ineficiente e é uma das principais desvantagens da *RL* - particularmente quando o vetor de parâmetro é de dimesão alta (o que implica em um grande espaço de solução para pesquisar, tornando difícil encontrar para onde se mover).
+
+Uma técnica muito popular em *RL* são *Actor Critic Methods* (Métodos de Ator/Crítico). Um método crítico consiste basicamente em um segundo módulo C, que é um módulo conhecido e treinável. É possível treinar o módulo C, que é diferenciável, para aproximar a função de custo/recompensa. A recompensa é um custo negativo, mais como uma punição. Essa é uma maneira de tornar a função de custo diferenciável, ou pelo menos aproximando-a por uma função diferenciável para que se possa retropropagar.
+
+<!-- ## [Advantages of SGD and backpropagation for traditional neural nets](https://www.youtube.com/watch?v=d9vdh3b787Y&t=1036s)
+
+### Advantages of Stochastic Gradient Descent (SGD)
+
+In practice, we use stochastic gradient to compute the gradient of the objective function w.r.t the parameters. Instead of computing the full gradient of the objective function, which is the average of all samples, stochastic gradient just takes one sample, computes the loss, $L$, and the gradient of the loss w.r.t the parameters, and then takes one step in the negative gradient direction.
+
+$$
+w \leftarrow w - \eta \frac{\partial L(x[p], y[p],w)}{\partial w}
+$$
+
+In the formula, $w$ is approached by $w$ minus the step-size, times the gradient of the per-sample loss function w.r.t the parameters for a given sample, ($x[p]$,$y[p]$).
+
+If we do this on a single sample, we will get a very noisy trajectory as shown in Figure 3. Instead of the loss going directly downhill, it’s stochastic. Every sample will pull the loss towards a different direction. It’s just the average that pulls us to the minimum of the average. Although it looks inefficient, it’s much faster than full batch gradient descent at least in the context of machine learning when the samples have some redundancy.
+
+| <center><img src="{{site.baseurl}}/images/week02/02-1/Figure2.png" alt="Figure2" style="zoom:80%;" /></center> |
+| <center>Figure 3: Stochastic Gradient Descent trajectory for per sample update </center>|
+
+In practice, we use batches instead of doing stochastic gradient descent on a single sample. We compute the average of the gradient over a batch of samples, not a single sample, and then take one step. The only reason for doing this is that we can make more efficient use of the existing hardware  (*i.e.* GPUs, multicore CPUs) if we use batches since it's easier to parallelize. Batching is the simplest way to parallelize.
+
+### Traditional neural network
+
+Traditional Neural Nets are basically interspersed layers of linear operations and point-wise non-linear operations. For linear operations, conceptually it is just a matrix-vector multiplication. We take the (input) vector multiplied by a matrix formed by the weights. The second type of operation is to take all the components of the weighted sums vector and pass it through some simple non-linearity (*i.e.* $\texttt{ReLU}(\cdot)$, $\tanh(\cdot)$, …).
+
+| <center><img src="{{site.baseurl}}/images/week02/02-1/Figure3.png" alt="Figure3" style="zoom:30%;" /></center> |
+|             <center>Figure 4: Traditional Neural Network             </center>|
+
+Figure 4 is an example of a 2-layer network, because what matters are the pairs (i.e linear+non-linear). Some people call it a 3-layer network because they count the variables. Note that if there are no non-linearities in the middle, we may as well have a single layer because the product of two linear functions is a linear function.
+
+Figure 5 shows how the linear and non-linear functional blocks of the network stack:
+
+| <center><img src="{{site.baseurl}}/images/week02/02-1/Figure4.png" alt="Figure4" style="zoom:30%;" /></center> |
+|  <center>Figure 5: Looking inside the linear and non-linear blocks   </center>|
+
+In the graph, $s[i]$ is the weighted sum of unit ${i}$ which is computed as:
+
+$$
+s[i]=\sum_{j \in UP(i)}w[i,j]\cdot z[j]
+$$
+
+where $UP(i)$ denotes the predecessors of $i$ and $z[j]$ is the $j$th output from the previous layer.
+
+The output $z[i]$ is computed as:
+
+$$
+z[i]=f(s[i])
+$$
+
+where $f$ is a non-linear function. -->
+
+## [Vantagens do *SGD* e retropropagação para redes neurais tradicionais](https://www.youtube.com/watch?v=d9vdh3b787Y&t=1036s)
+
+### Vantagens do Gradiente Descendente Estocástico *(SGD)*
+
+Na prática, usamos gradiente estocástico para calcular o gradiente da função objetivo em respeito aos parametros. Em vez de calcular o gradiente total da função objetivo, que é a média de todas as amostras, o gradiente estocástico apenas pega uma amostra, calcula a perda, $L$, e o gradiente da perda com respeito aos paremetros, e então dá um passo na direção negativa do gradiente.
+
+$$
+w \leftarrow w - \eta \frac{\partial L(x[p], y[p],w)}{\partial w}
+$$
+
+Na fórmula, $w$ é aproximado por $w$ menos o tamanho do passo, vezes o gradiente da função de perda por amostra com respeito aos parametros para uma dada amostra, ($x[p]$,$y[p]$).
+
+Se fizermos isso em uma única amostra, obteremos uma trajetória muito ruidosa, conforme mostrado na Figura 3. Em vez da perda ir diretamente para baixo, é estocástica. Cada amostra puxará a perda em uma direção diferente. É apenas a média que nos puxa para o mínimo da média. Embora pareça ineficiente, é muito mais rápido do que o gradiente descendente em lotes completo, pelo menos no contexto de aprendizado de máquina, quando as amostras têm alguma redundância.
+
+| <center><img src="{{site.baseurl}}/images/week02/02-1/Figure2.png" alt="Figura 2" style="zoom:80%;" /></center> |
+| <center>Figura 3: Trajetória do gradiente descendente estocástico para atualização por amostra </center>|
+
+Na prática, utilizamos lotes em vez de calcular o gradiente descendente estocástico em uma única amostra. Calculamos a média do gradiente em um lote de amostras, e não uma única amostra, e então damos um passo. A única razão para fazer isso é que podemos fazer um uso mais eficiente do hardware existente (*isto é,* GPUs, CPUs de multiplos núcleos) se usamos lotes, pois é mais fácil de paralelizar. Fazer uma tarefa em lotes é a maneira mais simples de paralelizar.
+
+### Rede neural tradicional
+
+Redes Neurais tradicionais são basicamente camadas intercaladas de operações lineares e operações não lineares pontuais. Para operações lineares, conceitualmente, é apenas uma multiplicação de matriz-vetor. Tomamos o vetor (entrada) multiplicado por uma matriz formada pelos pesos. O segundo tipo de operação é pegar todos os componentes do vetor de somas ponderadas e passá-los por alguma não linearidade simples (*isto é* $\texttt{ReLU}(\cdot)$, $\tanh(\cdot)$, …).
+
+| <center><img src="{{site.baseurl}}/images/week02/02-1/Figure3.png" alt="Figura 3" style="zoom:30%;" /></center> |
+|             <center>Figura 4: Rede Neural Tradicional             </center>|
+
+A Figura 4 é um exemplo de uma rede de 2 camadas, porque o que importa são os pares (isto é linear + não linear). Algumas pessoas chamam isto de uma rede de 3 camadas porque contam as variáveis. Observe que se não houver não linearidades no meio, podemos ter uma única camada porque o produto de duas funções lineares é uma função linear.
+
+A Figura 5 mostra os blocos funcionais lineares e não lineares da pilha de camadas da rede:
+
+| <center><img src="{{site.baseurl}}/images/week02/02-1/Figure4.png" alt="Figura 4" style="zoom:30%;" /></center> |
+|  <center>Figura 5: Olhando dentro dos blocos lineares e não lineares</center>|
+
+No gráfico, $s[i]$ é a soma ponderada da unidade ${i}$ que é calculado como:
+
+$$
+s[i]=\sum_{j \in UP(i)}w[i,j]\cdot z[j]
+$$
+
+Onde $UP(i)$ denota os predecessores de $i$ e $z[j]$ é a $j$th saída da camada anterior.
+
+A saída $z[i]$ é calculada como:
+
+$$
+z[i]=f(s[i])
+$$
+
+Onde $f$ é uma função não linear.
+
+<!-- ### Backpropagation through a non-linear function
+
+The first way to do backpropagation is to backpropagate through a non linear function. We take a particular non-linear function $h$ from the network and leave everything else in the blackbox.
+
+| <center><img src="{{site.baseurl}}/images/week02/02-1/Figure5.png" alt="Figure5" style="zoom: 25%;" /></center> |
+|    <center>Figure 6: Backpropagation through non-linear function     </center>|
+
+We are going to use the chain rule to compute the gradients:
+
+$$
+g(h(s))' = g'(h(s))\cdot h'(s)
+$$
+
+where $h'(s)$ is the derivative of $z$ w.r.t $s$ represented by $\frac{\mathrm{d}z}{\mathrm{d}s}$.
+To make the connection between derivatives clear, we rewrite the formula above as:
+
+$$
+\frac{\mathrm{d}C}{\mathrm{d}s} = \frac{\mathrm{d}C}{\mathrm{d}z}\cdot \frac{\mathrm{d}z}{\mathrm{d}s} = \frac{\mathrm{d}C}{\mathrm{d}z}\cdot h'(s)
+$$
+
+Hence if we have a chain of those functions in the network, we can backpropagate by multiplying by the derivatives of all the ${h}$ functions one after the other all the way back to the bottom.
+
+It’s more intuitive to think of it in terms of perturbations. Perturbing $s$ by $\mathrm{d}s$ will perturb $z$ by:
+
+$$\mathrm{d}z = \mathrm{d}s \cdot h'(s)$$
+
+This would in turn perturb $C$ by:
+
+$$
+\mathrm{d}C = \mathrm{d}z\cdot\frac{\mathrm{d}C}{\mathrm{d}z} = \mathrm{d}s\cdot h’(s)\cdot\frac{\mathrm{d}C}{\mathrm{d}z}
+$$
+
+Once again, we end up with the same formula as the one shown above. -->
+
+### Retropropagação através de uma função não linear
+
+A primeira maneira de fazer retropropagação é retropropagá-la por meio de uma função não linear. Tomamos uma função não linear particular $h$ da rede e deixamos todo o resto na caixa preta.
+
+| <center><img src="{{site.baseurl}}/images/week02/02-1/Figure5.png" alt="Figura 5" style="zoom: 25%;" /></center> |
+|    <center>Figura 6: Retropropagação por meio de função não linear     </center>|
+
+Vamos usar a regra da cadeia para calcular os gradientes:
+
+$$
+g(h(s))' = g'(h(s))\cdot h'(s)
+$$
+
+Onde $h'(s)$ é a derivada de $z$ com respeito a $s$ representada por $\frac{\mathrm{d}z}{\mathrm{d}s}$.
+Para tornar clara a conexão entre as derivadas, reescrevemos a fórmula acima como:
+
+$$
+\frac{\mathrm{d}C}{\mathrm{d}s} = \frac{\mathrm{d}C}{\mathrm{d}z}\cdot \frac{\mathrm{d}z}{\mathrm{d}s} = \frac{\mathrm{d}C}{\mathrm{d}z}\cdot h'(s)
+$$
+
+Portanto, se temos uma cadeia dessas funções na rede, podemos retropropagar multiplicando pelas derivadas de todos as ${h}$ funções uma após a outra, de volta ao fundo.
+
+É mais intuitivo pensar nisso em termos de perturbações. Pertubar $s$ por $\mathrm{d}s$ vai perturbar $z$ por:
+
+$$\mathrm{d}z = \mathrm{d}s \cdot h'(s)$$
+
+Isso, por sua vez, perturbaria $C$ por:
+
+$$
+\mathrm{d}C = \mathrm{d}z\cdot\frac{\mathrm{d}C}{\mathrm{d}z} = \mathrm{d}s\cdot h’(s)\cdot\frac{\mathrm{d}C}{\mathrm{d}z}
+$$
+
+Mais uma vez, terminamos com a mesma fórmula mostrada acima.
+
+<!-- ### Backpropagation through a weighted sum
+
+For a linear module, we do backpropagation through a weighted sum. Here we view the entire network as a blackbox except for 3 connections going from a ${z}$ variable to a bunch of $s$ variables.
+
+| <center><img src="{{site.baseurl}}/images/week02/02-1/Figure6.png" alt="Figure6" style="zoom: 25%;" /></center> |
+|        <center>Figure 7: Backpropagation through weighted sum        </center>|
+
+This time the perturbation is a weighted sum. $Z$ influences several variables. Perturbing $z$ by $\mathrm{d}z$ will perturb $s[0]$, $s[1]$ and $s[2]$ by:
+
+$$
+\mathrm{d}s[0]=w[0]\cdot \mathrm{d}z
+$$
+
+$$
+\mathrm{d}s[1]=w[1]\cdot \mathrm{d}z
+$$
+
+$$
+\mathrm{d}s[2]=w[2]\cdot\mathrm{d}z
+$$
+
+ This will perturb $C$ by
+
+$$
+\mathrm{d}C = \mathrm{d}s[0]\cdot \frac{\mathrm{d}C}{\mathrm{d}s[0]}+\mathrm{d}s[1]\cdot \frac{\mathrm{d}C}{\mathrm{d}s[1]}+\mathrm{d}s[2]\cdot\frac{\mathrm{d}C}{\mathrm{d}s[2]}
+$$
+
+Hence $C$ is going to vary by the sum of the 3 variations:
+
+$$
+\frac{\mathrm{d}C}{\mathrm{d}z} = \frac{\mathrm{d}C}{\mathrm{d}s[0]}\cdot w[0]+\frac{\mathrm{d}C}{\mathrm{d}s[1]}\cdot w[1]+\frac{\mathrm{d}C}{\mathrm{d}s[2]}\cdot w[2]
+$$ -->
+
+### Retropropagação por meio de uma soma ponderada
+
+Para um módulo linear, fazemos a retropropagação por meio de uma soma ponderada. Aqui, vemos toda a rede como uma caixa preta, exceto por 3 conexões saindo de uma variável ${z}$ para um monte de variáveis $s$.
+
+| <center><img src="{{site.baseurl}}/images/week02/02-1/Figure6.png" alt="Figura 6" style="zoom: 25%;" /></center> |
+|        <center>Figura 7: Retropropagação através da soma ponderada        </center>|
+
+Desta vez, a perturbação é uma soma ponderada. $Z$ influencia várias variáveis. Perturbar $z$ por $\mathrm{d}z$ vai perturbar $s[0]$, $s[1]$ e $s[2]$ por:
+
+$$
+\mathrm{d}s[0]=w[0]\cdot \mathrm{d}z
+$$
+
+$$
+\mathrm{d}s[1]=w[1]\cdot \mathrm{d}z
+$$
+
+$$
+\mathrm{d}s[2]=w[2]\cdot\mathrm{d}z
+$$
+
+ Isso vai perturbar $C$ por
+
+$$
+\mathrm{d}C = \mathrm{d}s[0]\cdot \frac{\mathrm{d}C}{\mathrm{d}s[0]}+\mathrm{d}s[1]\cdot \frac{\mathrm{d}C}{\mathrm{d}s[1]}+\mathrm{d}s[2]\cdot\frac{\mathrm{d}C}{\mathrm{d}s[2]}
+$$
+
+Conseqüentemente $C$ vai variar pela soma das 3 variações:
+
+$$
+\frac{\mathrm{d}C}{\mathrm{d}z} = \frac{\mathrm{d}C}{\mathrm{d}s[0]}\cdot w[0]+\frac{\mathrm{d}C}{\mathrm{d}s[1]}\cdot w[1]+\frac{\mathrm{d}C}{\mathrm{d}s[2]}\cdot w[2]
+$$
+
+<!-- ## [PyTorch implementation of neural network and a generalized backprop algorithm](https://www.youtube.com/watch?v=d9vdh3b787Y&t=2288s)
+
+### Block diagram of a traditional neural net
+
+- Linear blocks $s_{k+1}=w_kz_k$
+- Non-linear blocks $z_k=h(s_k)$
+
+  <center><img src="{{site.baseurl}}/images/week02/02-1/Figure 7.png" alt="Figure 7" style="zoom: 33%;" /></center>
+
+$w_k$: matrix $z_k$: vector $h$: application of scalar ${h}$ function to every component. This is a 3-layer neural net with pairs of linear and non-linear functions, though most modern neural nets do not have such clear linear and non-linear separations and are more complex.
+
+### PyTorch implementation
+
+```python
+import torch
+from torch import nn
+image = torch.randn(3, 10, 20)
+d0 = image.nelement()
+
+class mynet(nn.Module):
+    def __init__(self, d0, d1, d2, d3):
+        super().__init__()
+        self.m0 = nn.Linear(d0, d1)
+        self.m1 = nn.Linear(d1, d2)
+        self.m2 = nn.Linear(d2, d3)
+
+    def forward(self,x):
+        z0 = x.view(-1)  # flatten input tensor
+        s1 = self.m0(z0)
+        z1 = torch.relu(s1)
+        s2 = self.m1(z1)
+        z2 = torch.relu(s2)
+        s3 = self.m2(z2)
+        return s3
+model = mynet(d0, 60, 40, 10)
+out = model(image)
+```
+
+- We can implement neural nets with object oriented classes in PyTorch. First we define a class for the neural net and initialize linear layers in the constructor using predefined `nn.Linear` class. Linear layers have to be separate objects because each of them contains a parameter vector. The `nn.Linear` class also adds the bias vector implicitly. Then we define a forward function on how to compute outputs with $\text{torch.relu}$ function as the nonlinear activation. We don't have to initialize separate relu functions because they don't have parameters.
+
+- We do not need to compute the gradient ourselves since PyTorch knows how to back propagate and calculate the gradients given the `forward` function. -->
+
+## [Implementação em PyTorch de uma rede neural e um algoritmo de retropropagação generalizado](https://www.youtube.com/watch?v=d9vdh3b787Y&t=2288s)
+
+### Diagrama de blocos de uma rede neural tradicional
+
+- Blocos lineares $s_{k+1}=w_kz_k$
+- Blocos não lineares $z_k=h(s_k)$
+
+  <center><img src="{{site.baseurl}}/images/week02/02-1/Figure 7.png" alt="Figura 7" style="zoom: 33%;" /></center>
+
+$w_k$: matriz $z_k$: vetor $h$: aplicação da função escalar ${h}$ para cada componente. Esta é uma rede neural de 3 camadas com pares de funções lineares e não lineares, embora a maioria das redes neurais modernas não tenham tais separações lineares e não lineares claras e sejam mais complexas.
+
+### Implementação em PyTorch
+
+```python
+import torch
+from torch import nn
+image = torch.randn(3, 10, 20)
+d0 = image.nelement()
+
+class mynet(nn.Module):
+    def __init__(self, d0, d1, d2, d3):
+        super().__init__()
+        self.m0 = nn.Linear(d0, d1)
+        self.m1 = nn.Linear(d1, d2)
+        self.m2 = nn.Linear(d2, d3)
+
+    def forward(self,x):
+        z0 = x.view(-1)  # flatten input tensor
+        s1 = self.m0(z0)
+        z1 = torch.relu(s1)
+        s2 = self.m1(z1)
+        z2 = torch.relu(s2)
+        s3 = self.m2(z2)
+        return s3
+model = mynet(d0, 60, 40, 10)
+out = model(image)
+```
+
+- Podemos implementar redes neurais com classes orientadas a objetos em PyTorch. Primeiro, definimos uma classe para a rede neural e inicializamos camadas lineares no construtor usando a classe predefinida `nn.Linear`. Camadas lineares devem ser objetos separados porque cada uma delas contém um vetor de parâmetro. A classe `nn.Linear` também adiciona o vetor de tendência implicitamente. Em seguida, definimos uma função para  calcular as saídas com a função $\text{torch.relu}$ como a ativação não linear. Não precisamos inicializar funções retificadoras *(ReLu)* separadas porque elas não têm parâmetros.
+
+- Não precisamos calcular o gradiente nós mesmos, poisPyTorch sabe como retroceder e calcular os gradientes, dada a função `forward`.
+
+<!-- ### Backprop through a functional module
+
+We now present a more generalized form of backpropagation.
+
+| <center><img src="{{site.baseurl}}/images/week02/02-1/Figure9.png" alt="Figure9" style="zoom:33%;" /></center> |
+|    <center>Figure 8: Backpropagation through a functional module     </center>|
+
+- Using chain rule for vector functions
+
+  $$
+   z_g : [d_g\times 1]
+  $$
+
+  $$
+   z_f:[d_f\times 1]
+  $$
+
+  $$
+  \frac{\partial c}{\partial{z_f}}=\frac{\partial c}{\partial{z_g}}\frac{\partial {z_g}}{\partial{z_f}}
+  $$
+
+  $$
+  [1\times d_f]= [1\times d_g]\times[d_g\times d_f]
+  $$
+
+  This is the basic formula for $\frac{\partial c}{\partial{z_f}}$ using the chain rule. Note that the gradient of a scalar function with respect to a vector is a vector of the same size as the vector with respect to which you differentiate. In order to make the notations consistent, it is a row vector instead of a column vector.
+
+- Jacobian matrix
+
+  $$
+  \left(\frac{\partial{z_g}}{\partial {z_f}}\right)_{ij}=\frac{(\partial {z_g})_i}{(\partial {z_f})_j}
+  $$
+
+  We need $\frac{\partial {z_g}}{\partial {z_f}}$ (Jacobian matrix entries) to compute the gradient of the cost function with respect to $z_f$ given gradient of the cost function with respect to $z_g$. Each entry $ij$ is equal to the partial derivative of the $i$th component of the output vector with respect to the $j$th component of the input vector.
+
+  If we have a cascade of modules, we keep multiplying the Jacobian matrices of all the modules going down and we get the gradients w.r.t all the internal variables. -->
+
+### Retropropagação através de um módulo funcional
+
+Agora apresentamos uma forma mais generalizada de retropropagação.
+
+| <center><img src="{{site.baseurl}}/images/week02/02-1/Figure9.png" alt="Figura 9" style="zoom:33%;" /></center> |
+|    <center>Figura 8: Retropropagação através de um módulo funcional     </center>|
+
+- Usando a regra da cadeia para funções vetoriais
+
+  $$
+   z_g : [d_g\times 1]
+  $$
+
+  $$
+   z_f:[d_f\times 1]
+  $$
+
+  $$
+  \frac{\partial c}{\partial{z_f}}=\frac{\partial c}{\partial{z_g}}\frac{\partial {z_g}}{\partial{z_f}}
+  $$
+
+  $$
+  [1\times d_f]= [1\times d_g]\times[d_g\times d_f]
+  $$
+
+  Esta é a fórmula básica para $\frac{\partial c}{\partial{z_f}}$ usando a regra da cadeia. Observe que o gradiente de uma função escalar em relação a um vetor é um vetor do mesmo tamanho que o vetor em relação ao qual você diferencia. Para tornar as notações consistentes, é um vetor linha em vez de um vetor coluna.
+
+- Matriz Jacobiana
+
+  $$
+  \left(\frac{\partial{z_g}}{\partial {z_f}}\right)_{ij}=\frac{(\partial {z_g})_i}{(\partial {z_f})_j}
+  $$
+
+  Nós precisamos de $\frac{\partial {z_g}}{\partial {z_f}}$ (Entradas de matriz Jacobiana) para calcular o gradiente da função de custo em relação a $z_f$ dado o gradiente da função de custo em relação a $z_g$. Cada entrada $ij$ é igual à derivada parcial do $i$th componente do vetor de saída em relação ao $j$th componente do vetor de entrada.
+
+  Se tivermos os módulos em cascata, continuamos multiplicando as matrizes Jacobianas de todos os módulos descendo e obtemos os gradientes com respeito a todas as variáveis internas.
+
+<!-- ### Backprop through a multi-stage graph
+
+Consider a stack of many modules in a neural network as shown in Figure 9.
+
+| <center><img src="{{site.baseurl}}/images/week02/02-1/Figure10.png" alt="Figure10" style="zoom:33%;" /></center> |
+|         <center>Figure 9: Backprop through multi-stage graph         </center>|
+
+For the backprop algorithm, we need two sets of gradients - one with respect to the states (each module of the network) and one with respect to the weights (all the parameters in a particular module). So we have two Jacobian matrices associated with each module. We can again use chain rule for backprop.
+
+- Using chain rule for vector functions
+
+  $$
+  \frac{\partial c}{\partial {z_k}}=\frac{\partial c}{\partial {z_{k+1}}}\frac{\partial {z_{k+1}}}{\partial {z_k}}=\frac{\partial c}{\partial {z_{k+1}}}\frac{\partial f_k(z_k,w_k)}{\partial {z_k}}
+  $$
+
+  $$
+  \frac{\partial c}{\partial {w_k}}=\frac{\partial c}{\partial {z_{k+1}}}\frac{\partial {z_{k+1}}}{\partial {w_k}}=\frac{\partial c}{\partial {z_{k+1}}}\frac{\partial f_k(z_k,w_k)}{\partial {w_k}}
+  $$
+
+- Two Jacobian matrices for the module
+    - One with respect to $z[k]$
+    - One with respect to $w[k]$
+ -->
+
+### Retropropagação por meio de um gráfico de vários estágios
+
+Considere uma pilha de vários módulos em uma rede neural, conforme mostrado na Figura 9.
+
+| <center><img src="{{site.baseurl}}/images/week02/02-1/Figure10.png" alt="Figura 10" style="zoom:33%;" /></center> |
+|         <center>Figura 9: Backprop por meio de gráfico de vários estágios         </center>|
+
+Para o algoritmo de retropropagação, precisamos de dois conjuntos de gradientes - um em relação aos estados (cada módulo da rede) e um em relação aos pesos (todos os parâmetros em um módulo particular). Portanto, temos duas matrizes Jacobianas associadas a cada módulo. Podemos novamente usar a regra da cadeia para retropropagação.
+
+- Usando a regra da cadeia para funções vetoriais
+
+  $$
+  \frac{\partial c}{\partial {z_k}}=\frac{\partial c}{\partial {z_{k+1}}}\frac{\partial {z_{k+1}}}{\partial {z_k}}=\frac{\partial c}{\partial {z_{k+1}}}\frac{\partial f_k(z_k,w_k)}{\partial {z_k}}
+  $$
+
+  $$
+  \frac{\partial c}{\partial {w_k}}=\frac{\partial c}{\partial {z_{k+1}}}\frac{\partial {z_{k+1}}}{\partial {w_k}}=\frac{\partial c}{\partial {z_{k+1}}}\frac{\partial f_k(z_k,w_k)}{\partial {w_k}}
+  $$
+
+- Duas matrizes Jacobianas para o módulo
+    - Um em relação a $z[k]$
+    - Um em relação a $w[k]$

--- a/docs/pt/week02/02-2.md
+++ b/docs/pt/week02/02-2.md
@@ -1,0 +1,383 @@
+---
+lang: pt
+lang-ref: ch.02-2
+lecturer: Yann LeCun
+title: Gradientes de computação para módulos de NN e truques práticos para retropropagação
+authors: Micaela Flores, Sheetal Laad, Brina Seidel, Aishwarya Rajan
+date: 3 Feb 2020
+translation-date: 28 Fev 2021
+translator: Lenin Cristi
+---
+
+<!-- ## [A concrete example of backpropagation and intro to basic neural network modules](https://www.youtube.com/watch?v=d9vdh3b787Y&t=2989s)
+
+### Example
+
+We next consider a concrete example of backpropagation assisted by a visual graph. The arbitrary function $G(w)$ is input into the cost function $C$, which can be represented as a graph. Through the manipulation of multiplying the Jacobian matrices, we can transform this graph into the graph that will compute the gradients going backwards. (Note that PyTorch and TensorFlow do this automatically for the user, i.e. the forward graph is automatically "reversed" to create the derivative graph that backpropagates the gradient.)
+
+<center><img src="{{site.baseurl}}/images/week02/02-2/02-2-1.png" alt="Gradient diagram" style="zoom:40%;" /></center>
+
+In this example, the green graph on the right represents the gradient graph. Following the graph from the topmost node, it follows that
+
+$$
+\frac{\partial C(y,\bar{y})}{\partial w}=1 \cdot \frac{\partial C(y,\bar{y})}{\partial\bar{y}}\cdot\frac{\partial G(x,w)}{\partial w}
+$$
+
+In terms of dimensions, $\frac{\partial C(y,\bar{y})}{\partial w}$ is a row vector of size $1\times N$ where $N$ is the number of components of $w$; $\frac{\partial C(y,\bar{y})}{\partial \bar{y}}$  is a row vector of size $1\times M$, where $M$ is the dimension of the output; $\frac{\partial \bar{y}}{\partial w}=\frac{\partial G(x,w)}{\partial w}$ is a matrix of size $M\times N$, where $M$ is the number of outputs of $G$ and $N$ is the dimension of $w$.
+
+Note that complications might arise when the architecture of the graph is not fixed, but is data-dependent. For example, we could choose neural net module depending on the length of input vector. Though this is possible, it becomes increasingly difficult to manage this variation when the number of loops exceeds a reasonable amount. -->
+
+## [Um exemplo concreto de retropropagação e uma introdução aos módulos básicos da rede neural](https://www.youtube.com/watch?v=d9vdh3b787Y&t=2989s)
+
+### Exemplo
+
+A seguir, consideramos um exemplo concreto de retropropagação assistida por um gráfico visual. A função arbitrária $G(w)$ é a entrada da função de custo $C$, que pode ser representado como um gráfico. Através da manipulação de multiplicação das matrizes Jacobianas, podemos transformar este gráfico no gráfico que irá computar os gradientes indo para trás. (Observe que o PyTorch e o TensorFlow fazem isso automaticamente para o usuário, isto é, o gráfico progressivo é automaticamente "revertido" para criar o gráfico da derivada que retropropaga o gradiente.)
+
+<center><img src="{{site.baseurl}}/images/week02/02-2/02-2-1.png" alt="Diagrama de gradiente" style="zoom:40%;" /></center>
+
+Neste exemplo, o gráfico verde à direita representa o gráfico do gradiente. Seguindo o gráfico do nó superior, segue-se que
+
+$$
+\frac{\partial C(y,\bar{y})}{\partial w}=1 \cdot \frac{\partial C(y,\bar{y})}{\partial\bar{y}}\cdot\frac{\partial G(x,w)}{\partial w}
+$$
+
+Em termos de dimensões, $\frac{\partial C(y,\bar{y})}{\partial w}$ é um vetor linha de tamanho $1\times N$ onde $N$ é o número de componentes de $w$; $\frac{\partial C(y,\bar{y})}{\partial \bar{y}}$ é um vetor linha de tamanho $1\times M$, onde $M$ é a dimensão da saída; $\frac{\partial \bar{y}}{\partial w}=\frac{\partial G(x,w)}{\partial w}$ é uma matriz de tamanho $M\times N$, onde $M$ é o número de saídas de $G$ e $N$ é a dimensão de $w$.
+
+Observe que podem surgir complicações quando a arquitetura do gráfico não é fixada, mas depende dos dados. Por exemplo, poderíamos escolher o módulo de rede neural dependendo do comprimento do vetor de entrada. Embora isso seja possível, torna-se cada vez mais difícil gerenciar essa variação quando o número de loops excede uma quantidade razoável.
+
+<!-- ### Basic neural net modules
+
+There exist different types of pre-built modules besides the familiar Linear and ReLU modules. These are useful because they are uniquely optimized to perform their respective functions (as opposed to being built by a combination of other, elementary modules).
+
+- Linear: $Y=W\cdot X$
+
+  $$
+  \begin{aligned}
+  \frac{dC}{dX} &= W^\top \cdot \frac{dC}{dY} \\
+  \frac{dC}{dW} &= \frac{dC}{dY} \cdot X^\top
+  \end{aligned}
+  $$
+
+- ReLU: $y=(x)^+$
+
+  $$
+  \frac{dC}{dX} =
+      \begin{cases}
+        0 & x<0\\
+        \frac{dC}{dY} & \text{otherwise}
+      \end{cases}
+  $$
+
+- Duplicate: $Y_1=X$, $Y_2=X$
+
+  - Akin to a "Y - splitter" where both outputs are equal to the input.
+
+  - When backpropagating, the gradients get summed
+
+  - Can be split into $n$ branches similarly
+
+    $$
+    \frac{dC}{dX}=\frac{dC}{dY_1}+\frac{dC}{dY_2}
+    $$
+
+
+- Add: $Y=X_1+X_2$
+
+  - With two variables being summed, when one is perturbed, the output will be perturbed by the same quantity, i.e.
+
+    $$
+    \frac{dC}{dX_1}=\frac{dC}{dY}\cdot1 \quad \text{and}\quad \frac{dC}{dX_2}=\frac{dC}{dY}\cdot1
+    $$
+
+
+- Max: $Y=\max(X_1,X_2)$
+
+  -  Since this function can also be represented as
+
+    $$
+    Y=\max(X_1,X_2)=\begin{cases}
+          X_1 & X_1 > X_2 \\
+          X_2 & \text{else}
+       \end{cases}
+    \Rightarrow
+    \frac{dY}{dX_1}=\begin{cases}
+          1 & X_1 > X_2 \\
+          0 & \text{else}
+       \end{cases}
+    $$
+
+  - Therefore, by the chain rule,
+
+    $$
+    \frac{dC}{dX_1}=\begin{cases}
+          \frac{dC}{dY}\cdot1 & X_1 > X_2 \\
+          0 & \text{else}
+      \end{cases}
+    $$ -->
+
+### Módulos básicos de rede neural
+
+Existem diferentes tipos de módulos pré-construídos além dos familiares Linear e *ReLU* (Unidade Linear Retificada). Eles são úteis porque são otimizados exclusivamente para executar suas respectivas funções (em oposição a ser construído por uma combinação de outros módulos elementares).
+
+- Linear: $Y=W\cdot X$
+
+  $$
+  \begin{aligned}
+  \frac{dC}{dX} &= W^\top \cdot \frac{dC}{dY} \\
+  \frac{dC}{dW} &= \frac{dC}{dY} \cdot X^\top
+  \end{aligned}
+  $$
+
+- ReLU: $y=(x)^+$
+
+  $$
+  \frac{dC}{dX} =
+      \begin{cases}
+        0 & x<0\\
+        \frac{dC}{dY} & \text{otherwise}
+      \end{cases}
+  $$
+
+- Duplicado: $Y_1=X$, $Y_2=X$
+
+  - Semelhante a um "divisor em Y" onde ambas as saídas são iguais à entrada.
+
+  - Ao retropropagar, os gradientes são somados
+
+  - Pode ser dividido em $n$ ramos da mesma forma
+
+    $$
+    \frac{dC}{dX}=\frac{dC}{dY_1}+\frac{dC}{dY_2}
+    $$
+
+- Soma: $Y=X_1+X_2$
+
+  - Com duas variáveis sendo somadas, quando uma é perturbada, a saída será perturbada pela mesma quantidade, ou seja
+
+    $$
+    \frac{dC}{dX_1}=\frac{dC}{dY}\cdot1 \quad \text{and}\quad \frac{dC}{dX_2}=\frac{dC}{dY}\cdot1
+    $$
+
+- Máximo: $Y=\max(X_1,X_2)$
+
+  - Uma vez que esta função também pode ser representada como
+
+    $$
+    Y=\max(X_1,X_2)=\begin{cases}
+          X_1 & X_1 > X_2 \\
+          X_2 & \text{else}
+       \end{cases}
+    \Rightarrow
+    \frac{dY}{dX_1}=\begin{cases}
+          1 & X_1 > X_2 \\
+          0 & \text{else}
+       \end{cases}
+    $$
+
+  - Portanto, pela regra da cadeia
+
+    $$
+    \frac{dC}{dX_1}=\begin{cases}
+          \frac{dC}{dY}\cdot1 & X_1 > X_2 \\
+          0 & \text{else}
+      \end{cases}
+    $$
+
+<!-- ## [LogSoftMax *vs.* SoftMax](https://www.youtube.com/watch?v=d9vdh3b787Y&t=3953s)
+
+*SoftMax*, which is also a PyTorch module, is a convenient way of transforming a group of numbers into a group of positive numbers between $0$ and $1$ that sum to one. These numbers can be interpreted as a probability distribution. As a result, it is commonly used in classification problems. $y_i$ in the equation below is a vector of probabilities for all the categories.
+
+$$
+y_i = \frac{\exp(x_i)}{\sum_j \exp(x_j)}
+$$
+
+However, the use of softmax leaves the network susceptible to vanishing gradients. Vanishing gradient is a problem, as it prevents weights downstream from being modified by the neural network, which may completely stop the neural network from further training. The logistic sigmoid function, which is the softmax function for one value, shows that when $s$ is large, $h(s)$ is $1$, and when s is small, $h(s)$ is $0$. Because the sigmoid function is flat at $h(s) = 0$ and $h(s) = 1$, the gradient is $0$, which results in a vanishing gradient.
+
+<center><img src="{{site.baseurl}}/images/week02/02-2/02-2-2.png" alt="Sigmoid function to illustrate vanishing gradient" style="background-color:#DCDCDC;" /></center>
+
+$$
+h(s) = \frac{1}{1 + \exp(-s)}
+$$
+
+Mathematicians came up with the idea of logsoftmax in order to solve for the issue of the vanishing gradient created by softmax. *LogSoftMax* is another basic module in PyTorch. As can be seen in the equation below, *LogSoftMax* is a combination of softmax and log.
+
+$$
+\log(y_i )= \log\left(\frac{\exp(x_i)}{\Sigma_j \exp(x_j)}\right) = x_i - \log(\Sigma_j \exp(x_j))
+$$
+
+The equation below demonstrates another way to look at the same equation. The figure below shows the $\log(1 + \exp(s))$ part of the function. When $s$ is very small, the value is $0$, and when $s$ is very large, the value is $s$. As a result it doesn’t saturate, and the vanishing gradient problem is avoided.
+
+$$
+\log\left(\frac{\exp(s)}{\exp(s) + 1}\right)= s - \log(1 + \exp(s))
+$$
+
+<center><img src="{{site.baseurl}}/images/week02/02-2/02-2-3.png" width='400px' alt="Plot of logarithmic part of the functions" /></center> -->
+
+## [LogSoftMax *versus* SoftMax](https://www.youtube.com/watch?v=d9vdh3b787Y&t=3953s)
+
+*SoftMax*, que também é um módulo PyTorch, é uma maneira conveniente de transformar um grupo de números em um grupo de números positivos entre $0$ e $1$ cuja soma dá um. Esses números podem ser interpretados como uma distribuição de probabilidade. Como resultado, é comumente usado em problemas de classificação. $y_i$ na equação abaixo é um vetor de probabilidades para todas as categorias.
+
+$$
+y_i = \frac{\exp(x_i)}{\sum_j \exp(x_j)}
+$$
+
+No entanto, o uso de softmax deixa a rede suscetível ao desaparecimento de gradientes. Desaparecimentos de gradientes são um problema, uma vez que impede que os pesos sejam modificados pela rede neural, o que por sua vez pode impedir completamente a rede neural de continuar treinando. A função sigmóide logística, que é a função softmax para um valor, mostra que quando $s$ é grande, $h(s)$ é $1$, e quando s é pequeno, $h(s)$ é $0$. Porque a função sigmóide é plana em $h(s) = 0$ e $h(s) = 1$, o gradiente é $0$, o que resulta em um desaparecimento do gradiente.
+
+<center><img src="{{site.baseurl}}/images/week02/02-2/02-2-2.png" alt="Função sigmóide para ilustrar o desaparecimento do gradiente" style="background-color:#DCDCDC;" /></center>
+
+$$
+h(s) = \frac{1}{1 + \exp(-s)}
+$$
+
+Os matemáticos tiveram a ideia da logsoftmax a fim de resolver o problema do desaparecimento do gradiente criado pela softmax. *LogSoftMax* é outro módulo básico do PyTorch. Como pode ser visto na equação abaixo, *LogSoftMax* é uma combinação das funções softmax e logarítmica.
+
+$$
+\log(y_i )= \log\left(\frac{\exp(x_i)}{\Sigma_j \exp(x_j)}\right) = x_i - \log(\Sigma_j \exp(x_j))
+$$
+
+A equação abaixo demonstra outra maneira de olhar para a mesma equação. A figura abaixo mostra o $\log(1 + \exp(s))$ como parte da função. Quando $s$ é muito pequeno, o valor é $0$, e quando $s$ é muito grande, o valor é $s$. Como resultado, ela não satura, e o problema do desaparecimento do gradiente é evitado.
+
+$$
+\log\left(\frac{\exp(s)}{\exp(s) + 1}\right)= s - \log(1 + \exp(s))
+$$
+
+<center><img src="{{site.baseurl}}/images/week02/02-2/02-2-3.png" width='400px' alt="Gráfico da parte logarítmica das funções" /></center>
+
+<!-- ## [Practical tricks for backpropagation](https://www.youtube.com/watch?v=d9vdh3b787Y&t=4891s)
+
+
+### Use ReLU as the non-linear activation function
+
+ReLU works best for networks with many layers, which has caused alternatives like the sigmoid function and hyperbolic tangent $\tanh(\cdot)$ function to fall out of favour. The reason ReLU works best is likely due to its single kink which makes it scale equivariant.
+
+
+### Use cross-entropy loss as the objective function for classification problems
+
+Log softmax, which we discussed earlier in the lecture, is a special case of cross-entropy loss. In PyTorch, be sure to provide the cross-entropy loss function with *log* softmax as input (as opposed to normal softmax).
+
+
+### Use stochastic gradient descent on minibatches during training
+
+As discussed previously, minibatches let you train more efficiently because there is redundancy in the data; you shouldn't need to make a prediction and calculate the loss on every single observation at every single step to estimate the gradient.
+
+
+### Shuffle the order of the training examples when using stochastic gradient descent
+
+Order matters. If the model sees only examples from a single class during each training step, then it will learn to predict that class without learning why it ought to be predicting that class. For example, if you were trying to classify digits from the MNIST dataset and the data was unshuffled, the bias parameters in the last layer would simply always predict zero, then adapt to always predict one, then two, *etc*. Ideally, you should have samples from every class in every minibatch.
+
+However, there's ongoing debate over whether you need to change the order of the samples in every pass (epoch).
+
+
+### Normalize the inputs to have zero mean and unit variance
+
+Before training, it's useful to normalize each input feature so that it has a mean of zero and a standard deviation of one. When using RGB image data, it is common to take mean and standard deviation of each channel individually and normalize the image channel-wise. For example, take the mean $m_b$ and standard deviation $\sigma_b$ of all the blue values in the dataset, then normalize the blue values for each individual image as
+
+$$
+b_{[i,j]}^{'} = \frac{b_{[i,j]} - m_b}{\max(\sigma_b, \epsilon)}
+$$
+
+where $\epsilon$ is an arbitrarily small number that we use to avoid division by zero. Repeat the same for green and red channels. This is necessary to get a meaningful signal out of images taken in different lighting; for example, day lit pictures have a lot of red while underwater pictures have almost none.
+
+
+### Use a schedule to decrease the learning rate
+
+The learning rate should fall as training goes on. In practice, most advanced models are trained by using algorithms like Adam which adapt the learning rate instead of simple SGD with a constant learning rate.
+
+
+### Use L1 and/or L2 regularization for weight decay
+
+You can add a cost for large weights to the cost function. For example, using L2 regularization, we would define the loss $L$ and update the weights $w$ as follows:
+
+$$
+L(S, w) = C(S, w) + \alpha \Vert w \Vert^2\\
+\frac{\partial R}{\partial w_i} = 2w_i\\
+w_i = w_i - \eta\frac{\partial L}{\partial w_i} = w_i - \eta \left( \frac{\partial C}{\partial w_i} + 2 \alpha w_i \right)
+$$
+
+To understand why this is called weight decay, note that we can rewrite the above formula to show that we multiply $w_i$ by a constant less than one during the update.
+
+$$
+w_i = (1 - 2 \eta \alpha) w_i - \eta\frac{\partial C}{\partial w_i}
+$$
+
+L1 regularization (Lasso) is similar, except that we use $\sum_i \vert w_i\vert$ instead of $\Vert w \Vert^2$.
+
+Essentially, regularization tries to tell the system to minimize the cost function with the shortest weight vector possible. With L1 regularization, weights that are not useful are shrunk to $0$. -->
+
+## [Truques práticos para retropropagação](https://www.youtube.com/watch?v=d9vdh3b787Y&t=4891s)
+
+### Use *ReLU* como função de ativação não linear
+
+*ReLU* funciona melhor para redes com muitas camadas, o que tem causado alternativas como as funções sigmóide e tangente hiperbólica $\tanh(\cdot)$ cairem em desgraça. O motivo pelo qual *ReLU* funciona melhor é provavelmente devido à sua única torção, que a torna equivariante na escala.
+
+### Use a perda de entropia cruzada *(cross-entropy loss)* como função objetivo para problemas de classificação
+
+*Log softmax*, que discutimos anteriormente nesta aula, é um caso especial de perda de entropia cruzada. No PyTorch, certifique-se de fornecer a função de perda de entropia cruzada com *log* softmax como entrada (em vez da softmax normal).
+
+### Use o gradiente descendente estocástico *(SGD)* em mini lotes durante o treinamento
+
+Conforme discutimos anteriormente, mini lotes permitem que você treine com mais eficiência porque há redundância nos dados; você não deve precisar fazer uma previsão e calcular a perda em cada observação e em cada etapa para estimar o gradiente.
+
+### Misture a ordem das amostras de treinamento ao usar o gradiente descendente estocástico
+
+A ordem importa. Se o modelo vir apenas exemplos de uma única classe durante cada etapa de treinamento, ele aprenderá a prever aquela classe sem aprender por que deveria estar prevendo aquela classe. Por exemplo, se você estava tentando classificar dígitos do conjunto de dados MNIST e os dados não forem misturados, os parâmetros de tendência na última camada simplesmente sempre preverão zero, então se adaptarão para sempre prever um, então dois, *etc*. Idealmente, você deve ter amostras de todas as classes em cada mini lote.
+
+No entanto, há atualmente um debate sobre se você precisa de fato alterar a ordem das amostras em cada passagem (epoch).
+
+### Normalize as entradas para ter média zero e variância unitária
+
+Antes do treinamento, é útil normalizar cada recurso de entrada para que tenha uma média de zero e um desvio padrão de um. Ao usar dados de imagem RGB, é comum tomar a média e o desvio padrão de cada canal individualmente e normalizar a imagem em termos de canal. Por exemplo, pegue a média $m_b$ e desvio padrão $\sigma_b$ de todos os valores de azul no conjunto de dados, em seguida, normalize os valores de azul para cada imagem individual como
+
+$$
+b_{[i,j]}^{'} = \frac{b_{[i,j]} - m_b}{\max(\sigma_b, \epsilon)}
+$$
+
+onde $\epsilon$ é um número arbitrariamente pequeno que usamos para evitar a divisão por zero. Repita o mesmo para os canais verde e vermelho. Isso é necessário para obter um sinal significativo de imagens tiradas em iluminação diferente; por exemplo, as fotos iluminadas pelo dia têm muito vermelho, enquanto as fotos subaquáticas quase nenhum.
+
+### Programe para diminuir a taxa de aprendizagem
+
+A taxa de aprendizagem deve cair conforme o treinamento avança. Na prática, a maioria dos modelos avançados são treinados usando algoritmos como o Adam, que adaptam a taxa de aprendizado em vez do SGD simples com uma taxa de aprendizado constante.
+
+### Use regularização L1 e/ou L2 para a queda de peso
+
+Você pode adicionar custo para grandes pesos à função de custo. Por exemplo, usando regularizção L2, nós definiríamos a perda $L$ e atualizaríamos os pesos $w$ do seguinte modo:
+
+$$
+L(S, w) = C(S, w) + \alpha \Vert w \Vert^2\\
+\frac{\partial R}{\partial w_i} = 2w_i\\
+w_i = w_i - \eta\frac{\partial L}{\partial w_i} = w_i - \eta \left( \frac{\partial C}{\partial w_i} + 2 \alpha w_i \right)
+$$
+
+Para entender por que isso é chamado de queda de peso, note que podemos reescrever a fórmula acima para mostrar que multiplicamos $w_i$ por uma constante menor que um durante a atualização.
+
+$$
+w_i = (1 - 2 \eta \alpha) w_i - \eta\frac{\partial C}{\partial w_i}
+$$
+
+A regularização L1 (Lasso) é semelhante, exceto que usamos $\sum_i \vert w_i\vert$ ao invés de $\Vert w \Vert^2$.
+
+Essencialmente, a regularização tenta dizer ao sistema para minimizar a função de custo com o vetor de peso mais curto possível. Com a regularização L1, os pesos que não são úteis são reduzidos para $0$.
+
+<!-- ### Weight initialisation
+
+The weights need to be initialised at random, however, they shouldn't be too large or too small such that output is roughly of the same variance as that of input. There are various weight initialisation tricks built into PyTorch. One of the tricks that works well for deep models is Kaiming initialisation where the variance of the weights is inversely proportional to square root of number of inputs. -->
+
+### Inicialização de peso
+
+Os pesos precisam ser inicializados aleatoriamente, no entanto, eles não devem ser muito grandes ou muito pequenos, de modo que a saída tenha aproximadamente a mesma variância da entrada. Existem vários truques de inicialização de peso embutidos no PyTorch. Um dos truques que funcionam bem para modelos profundos é a inicialização Kaiming onde a variância dos pesos é inversamente proporcional à raiz quadrada do número de entradas.
+
+<!-- ### Use dropout
+
+Dropout is another form of regularization. It can be thought of as another layer of the neural net: it takes inputs, randomly sets $n/2$ of the inputs to zero, and returns the result as output. This forces the system to take information from all input units rather than becoming overly reliant on a small number of input units thus distributing the information across all of the units in a layer. This method was initially proposed by <a href="https://arxiv.org/abs/1207.0580">Hinton et al (2012)</a>.
+
+For more tricks, see  <a href="http://yann.lecun.com/exdb/publis/pdf/lecun-98b.pdf">LeCun et al 1998</a>.
+
+Finally, note that backpropagation doesn't just work for stacked models; it can work for any directed acyclic graph (DAG) as long as there is a partial order on the modules. -->
+
+### Use o *dropout*
+
+*Dropout* é outra forma de regularização. Pode ser pensado como outra camada da rede neural: toma as entradas, randomicamente estabelece $n/2$ conjuntos de entradas para zero, e retorna o resultado como saída. Isso força o sistema a obter informações de todas as unidades de entrada, em vez de se tornar excessivamente dependente de um pequeno número delas, distribuindo assim, as informações por todas as unidades em uma camada. Este método foi inicialmente proposto por <a href="https://arxiv.org/abs/1207.0580">Hinton et al (2012)</a>.
+
+Para mais truques, veja  <a href="http://yann.lecun.com/exdb/publis/pdf/lecun-98b.pdf">LeCun et al 1998</a>.
+
+Por fim, observe que a retropropagação não funciona apenas para modelos empilhados; ela pode funcionar para qualquer gráfico acíclico direcionado (DAG) contanto que haja uma ordem parcial nos módulos.

--- a/docs/pt/week02/02-3.md
+++ b/docs/pt/week02/02-3.md
@@ -1,0 +1,580 @@
+---
+lang: pt
+lang-ref: ch.02-3
+lecturer: Alfredo Canziani
+title: Redes neurais artificiais (ANNs)
+authors:
+date: 4 Feb 2020
+typora-root-url: 02-3
+translation-date: 28 Fev 2021
+translator: Lenin Cristi
+---
+
+<!-- ## [Supervised learning for classification](https://www.youtube.com/watch?v=WAn6lip5oWk&t=150s)
+
+* Consider **Fig. 1(a)** below. The points in this graph lie on the branches of the spiral, and live in $\R^2$. Each colour represents a class label. The number of unique classes is $K = 3$. This is represented mathematically by **Eqn. 1(a)**.
+
+* **Fig. 1(b)** shows a similar spiral, with an added Gaussian noise term. This is represented mathematically by **Eqn. 1(b)**.
+
+  In both cases, these points are not linearly separable.
+
+  <center>
+  <table border="0">
+    <td>
+      <center>
+    <img src="{{site.baseurl}}/images/week02/02-3/clean-spiral.png" width="350px" /><br>
+       <b>Fig. 1(a)</b> "Clean" 2D spiral
+       </center>
+      </td>
+      <td>
+      <center>
+      <img src="{{site.baseurl}}/images/week02/02-3/noisy-spiral.png" width="350px" /><br>
+       <b>Fig. 1(b)</b> "Noisy" 2D spiral
+       </center>
+      </td>
+  </table>
+  </center>
+
+
+$$
+X_{k}(t)=t\left(\begin{array}{c}{\sin \left[\frac{2 \pi}{K}(2 t+k-1)\right]} \\ {\cos \left[\frac{2 \pi}{K}(2 t+k-1)\right]}\end{array}\right) \\
+0 \leq t \leq 1, \quad k=1, ..., K
+$$
+
+  <center><b>Eqn. 1(a)</b> </center>
+
+$$
+  X_{k}(t)=t\left(\begin{array}{c}{\sin \left[\frac{2 \pi}{K}(2 t+k-1 +\mathcal{N}\left(0, \sigma^{2}\right))\right]} \\ {\cos \left[\frac{2 \pi}{K}(2 t+k-1 +\mathcal{N}\left(0, \sigma^{2}\right))\right]}\end{array}\right)\\0 \leq t \leq 1, \quad k=1, ..., K
+$$
+
+<center><b>Eqn. 1(b)</b></center>
+
+What does it mean to perform **classification**? Consider the case of **logistic regression**. If logistic regression for classification is applied to this data, it will create a set of **linear planes** (decision boundaries) in an attempt to separate the data into its classes. The issue with this solution is that in each region, there are points belonging to multiple classes. The branches of the spiral cross the linear decision boundaries. This is **not** a great solution!
+
+**How do we fix this?** We transform the input space such that the data are forced to be linearly separable. Over the course of training a neural network to do this, the decision boundaries that it learns will try to adapt to the distribution of the training data.
+
+**Note:** A neural network is always represented from the **bottom up**. The first layer is at the bottom, and the last at the top. This is because conceptually, the input data are low-level features for whatever task the neural network is attempting. As the data traverse **upward** through the network, each subsequent layer extracts features at a higher level. -->
+
+## [Aprendizagem supervisionada para classificação](https://www.youtube.com/watch?v=WAn6lip5oWk&t=150s)
+
+* Considere a **Fig. 1(a)** abaixo. Os pontos neste gráfico estão nos ramos da espiral, no intervalo $\R^2$. Cada cor representa um rótulo de classe. O número de classes únicas é $K = 3$. Isso é representado matematicamente por **Eqn. 1(a)**.
+
+* A **Fig. 1(b)** mostra uma espiral semelhante, com um termo de ruído Gaussiano adicionado. Isso é representado matematicamente por **Eqn. 1(b)**.
+
+  Em ambos os casos, esses pontos não são linearmente separáveis.
+
+  <center>
+  <table border="0">
+    <td>
+      <center>
+    <img src="{{site.baseurl}}/images/week02/02-3/clean-spiral.png" width="350px" /><br>
+       <b>Fig. 1(a)</b> Espiral 2D "limpa"
+       </center>
+      </td>
+      <td>
+      <center>
+      <img src="{{site.baseurl}}/images/week02/02-3/noisy-spiral.png" width="350px" /><br>
+       <b>Fig. 1(b)</b> Espiral 2D "ruidosa"
+       </center>
+      </td>
+  </table>
+  </center>
+
+
+$$
+X_{k}(t)=t\left(\begin{array}{c}{\sin \left[\frac{2 \pi}{K}(2 t+k-1)\right]} \\ {\cos \left[\frac{2 \pi}{K}(2 t+k-1)\right]}\end{array}\right) \\
+0 \leq t \leq 1, \quad k=1, ..., K
+$$
+
+  <center><b>Eqn. 1(a)</b> </center>
+
+$$
+  X_{k}(t)=t\left(\begin{array}{c}{\sin \left[\frac{2 \pi}{K}(2 t+k-1 +\mathcal{N}\left(0, \sigma^{2}\right))\right]} \\ {\cos \left[\frac{2 \pi}{K}(2 t+k-1 +\mathcal{N}\left(0, \sigma^{2}\right))\right]}\end{array}\right)\\0 \leq t \leq 1, \quad k=1, ..., K
+$$
+
+<center><b>Eqn. 1(b)</b></center>
+
+O que significa realizar uma **classificação**? Considere o caso da **regressão logística**. Se a regressão logística para classificação for aplicada a esses dados, ela vai criar um conjunto de **planos lineares** (limites de decisão) em uma tentativa de separar os dados em suas classes. O problema com esta solução é que em cada região, existem pontos pertencentes a várias classes. Os ramos da espiral cruzam os limites de decisão linear. Esta **não** é a melhor solução!
+
+**Como consertar isso?** Nós transformamos o espaço de entrada de forma que os dados sejam forçados a serem linearmente separáveis. Durante o treinamento de uma rede neural para realizar essa tarefa, os limites de decisão que ela aprende tentarão se adaptar à distribuição dos dados de treinamento.
+
+**Nota:** Uma rede neural é sempre representada a partir **de baixo para cima**. A primeira camada está na parte inferior e a última no topo. Isso ocorre porque, conceitualmente, os dados de entrada são características de baixo nível para qualquer tarefa que a rede neural esteja tentando. Conforme os dados percorrem **para cima** pela rede, cada camada subsequente extrai recursos em um nível superior.
+
+<!-- ## Training data
+
+Last week, we saw that a newly initialised neural network transforms its input in an arbitrary way. This transformation, however, isn't **(initially)** instrumental in performing the task at hand. We explore how, using data, we can force this transformation to have some meaning that is relevant to the task at hand. The following are data used as training input for a network.
+
+* $\vect{X}$ represents the input data, a matrix of dimensions $m$ (number of training data points) x $n$ (dimensionality of each input point). In case of the data shown in Figures **1(a)** and **1(b)**, $n = 2$.
+
+<center>
+<img src="{{site.baseurl}}/images/week02/02-3/training-data.png" width="600px" /><br>
+<b>Fig. 2</b> Training data
+</center>
+
+* Vector $\vect{c}$  and matrix $\boldsymbol{Y}$ both represent class labels for each of the $m$ data points. In the example above, there are $3$ distinct classes.
+
+  * $c_i \in \lbrace 1, 2, \cdots, K \rbrace$, and $\vect{c} \in \R^m$. However, we may not use $\vect{c}$ as training data. If we use distinct numeric class labels  $c_i \in \lbrace 1, 2, \cdots, K \rbrace$, the network may infer an order within the classes that isn't representative of the data distribution.
+  * To bypass this issue, we use a **one-hot encoding**. For each label $c_i$, a $K$ dimensional zero-vector $\vect{y}^{(i)}$ is created, which has the $c_i$-th element set to $1$ (see **Fig. 3** below).
+
+<center>
+<img src="{{site.baseurl}}/images/week02/02-3/one-hot.png" width="250px" /><br>
+<b>Fig. 3</b> One hot encoding
+</center>
+
+  * Therefore, $\boldsymbol Y \in \R^{m \times K}$. This matrix can also be thought of as having some probabilistic mass, which is fully concentrated on one of the $K$ spots. -->
+
+## Dados de treinamento
+
+Na semana passada, vimos que uma rede neural recém-inicializada transforma sua entrada de maneira arbitrária. Essa transformação, no entanto, não é **(inicialmente)** instrumental na execução da tarefa em questão. Exploraremos agora como, usando dados, podemos forçar essa transformação a ter algum significado que seja relevante para a tarefa em questão. A seguir estão os dados usados como entrada de treinamento para uma rede.
+
+* $\vect{X}$ representa os dados de entrada, uma matriz de dimensões $m$ (número de pontos de dados de treinamento) x $n$ (dimensão de cada ponto de entrada). No caso dos dados mostrados nas Figuras **1(a)** e **1(b)**, $n = 2$.
+
+<center>
+<img src="{{site.baseurl}}/images/week02/02-3/training-data.png" width="600px" /><br>
+<b>Fig. 2</b> Dados de treinamento
+</center>
+
+* O vetor $\vect{c}$ e a matriz $\boldsymbol{Y}$ ambos representam rótulos de classe para cada um dos $m$ pontos de dados. No exemplo acima, existem $3$ classes distintas.
+
+  * $c_i \in \lbrace 1, 2, \cdots, K \rbrace$, e $\vect{c} \in \R^m$. De qualquer modo, não podemos usar $\vect{c}$ como dados de treinamento. Se usarmos rótulos de classe numéricos distintos $c_i \in \lbrace 1, 2, \cdots, K \rbrace$, a rede pode inferir uma ordem dentro das classes que não é representativa da distribuição dos dados.
+  * Para contornar esse problema, usamos um método **one-hot encoding**. Para cada etiqueta $c_i$, um vetor de dimensão $K$ zerado $\vect{y}^{(i)}$ é criado, no qual o $c_i$-ésimo elemento é setado para $1$ (veja a **Fig. 3** abaixo).
+
+<center>
+<img src="{{site.baseurl}}/images/week02/02-3/one-hot.png" width="250px" /><br>
+<b>Fig. 3</b> Codificação *One hot*
+</center>
+
+  * Portanto, $\boldsymbol Y \in \R^{m \times K}$. Esta matriz também pode ser pensada como tendo alguma massa probabilística, que está totalmente concentrada em um dos $K$ pontos.
+
+<!--
+## Fully (FC) connected layers
+
+We will now take a look at what a fully connected (FC) network is, and how it works.
+
+<center>
+<img src="{{site.baseurl}}/images/week02/02-3/FC-net.png" height="250px" /><br>
+<b>Fig. 4</b> Fully connected neural network
+</center>
+
+Consider the network shown above in **Fig. 4**. The input data, $\boldsymbol x$, is subject to an affine transformation defined by $\boldsymbol W_h$, followed by a non-linear transformation. The result of this non-linear transformation is denoted as $\boldsymbol h$, representing a **hidden** output, *i.e* one that is not **seen** from outside the network. This is followed by another affine transformation ($\boldsymbol W_y$), followed by another non-linear transformation. This produces the final output, $\boldsymbol{\hat{y}}$. This network can be represented mathematically by the equations in **Eqn. 2** below. $f$ and $g$ are both non-linearities.
+
+$$
+\begin{aligned}
+&\boldsymbol h=f\left(\boldsymbol{W}_{h} \boldsymbol x+ \boldsymbol b_{h}\right)\\
+&\boldsymbol{\hat{y}}=g\left(\boldsymbol{W}_{y} \boldsymbol h+ \boldsymbol b_{y}\right)
+\end{aligned}
+$$
+
+<center><b>Eqn. 2</b> Mathematics behind a FC network</center>
+
+A basic neural network such as the one shown above is merely a set of successive pairs, with each pair being an affine transformation followed by a non-linear operation (squashing). Frequently used non-linear functions include ReLU, sigmoid, hyperbolic tangent, and softmax.
+
+The network shown above is a 3-layer network:
+
+ 1. input neuron
+ 2. hidden neuron
+ 3. output neuron
+
+Therefore, a $3$-layer neural network has $2$ affine transformations. This can be extended to a $n$-layer network.
+
+Now let's move to a more complicated case.
+
+Let's do a case of 3 hidden layers, fully connected in each layer. An illustration can be found in **Fig. 5**
+
+<center>
+<img src="{{site.baseurl}}/images/week02/02-3/pre-inference4layers.png" /><br>
+<b>Fig. 5</b> Neural net with 3 hidden layers
+</center>
+
+Let's consider a neuron $j$ in the second layer. It's activation is:
+
+$$
+a^{(2)}_j = f(\boldsymbol w^{(j)} \boldsymbol x + b_j) = f\Big( \big(\sum_{i=1}^n w_i^{(j)} x_i\big) +b_j ) \Big)
+$$
+
+where $\vect{w}^{(j)}$ is the $j$-th row of $\vect{W}^{(1)}$.
+
+Notice that the activation of the input layer in this case is just the identity. The hidden layers can have activations like ReLU, hyperbolic tangent, sigmoid, soft (arg)max, *etc*.
+
+The activation of the last layer in general would depend on your use case, as explained in [this](https://piazza.com/class/k5spqaanqk51ks?cid=36) Piazza post. -->
+
+## Camadas totalmente conectadas (FC)
+
+Vamos agora dar uma olhada no que é uma rede totalmente conectada (FC) e como ela funciona.
+
+<center>
+<img src="{{site.baseurl}}/images/week02/02-3/FC-net.png" height="250px" /><br>
+<b>Fig. 4</b> Rede neural totalmente conectada
+</center>
+
+Considere a rede mostrada acima na **Fig. 4**. Os dados de entrada, $\boldsymbol x$, estão sujeitos a uma transformação afim definida por $\boldsymbol W_h$, seguida por uma transformação não linear. O resultado desta transformação não linear é denotado como $\boldsymbol h$, representando uma saída **oculta**, *isto é* aquela que não é **vista** de fora da rede. Isso é seguido por outra transformação afim ($\boldsymbol W_y$), seguida por outra transformação não linear. Isso produz a saída final, $\boldsymbol{\hat{y}}$. Esta rede pode ser representada matematicamente pelas equações em **Eqn. 2** logo abaixo. $f$ e $g$ são ambas não linearidades.
+
+$$
+\begin{aligned}
+&\boldsymbol h=f\left(\boldsymbol{W}_{h} \boldsymbol x+ \boldsymbol b_{h}\right)\\
+&\boldsymbol{\hat{y}}=g\left(\boldsymbol{W}_{y} \boldsymbol h+ \boldsymbol b_{y}\right)
+\end{aligned}
+$$
+
+<center><b>Eqn. 2</b> A matemática por trás de uma rede FC</center>
+
+Uma rede neural básica como a mostrada acima é meramente um conjunto de pares sucessivos, com cada par sendo uma transformação afim seguida por uma operação não linear (achatadas). Funções não lineares usadas com frequência incluem *ReLU*, sigmóide, tangente hiperbólica e softmax.
+
+A rede mostrada acima é uma rede de 3 camadas:
+
+ 1. neurônio de entrada
+ 2. neurônio oculto
+ 3. neurônio de saída
+
+Sendo assim, uma rede de $3$ camadas têm $2$ transformações afins. Isso pode ser estendido a uma rede de $n$ camadas.
+
+Agora vamos passar para um caso mais complicado.
+
+Vamos ver um caso com 3 camadas ocultas, totalmente conectadas em cada camada. Uma ilustração pode ser vista na **Fig. 5**
+
+<center>
+<img src="{{site.baseurl}}/images/week02/02-3/pre-inference4layers.png" /><br>
+<b>Fig. 5</b> Rede neural com 3 camadas ocultas
+</center>
+
+Vamos considerar o neurônio $j$ na segunda camada. Sua ativação é:
+
+$$
+a^{(2)}_j = f(\boldsymbol w^{(j)} \boldsymbol x + b_j) = f\Big( \big(\sum_{i=1}^n w_i^{(j)} x_i\big) +b_j ) \Big)
+$$
+
+onde $\vect{w}^{(j)}$ é a $j$-ésima linha de $\vect{W}^{(1)}$.
+
+Observe que a ativação da camada de entrada, neste caso, é apenas a identidade. As camadas ocultas podem ter ativações como *ReLU*, tangente hiperbólica, sigmóide, soft (arg)max, *etc*.
+
+A ativação da última camada em geral depende do seu caso de uso, conforme explicado neste artigo no Piazza [this](https://piazza.com/class/k5spqaanqk51ks?cid=36).
+
+<!-- ## Neural network (inference)
+
+Let's think about the three-layer (input, hidden, output) neural network again, as seen in **Fig. 6**
+
+<center>
+<img src="{{site.baseurl}}/images/week02/02-3/2-layer-inference.png" height="250px"/><br>
+<b>Fig. 6</b> Three-layer neural network
+</center>
+
+What kind of functions are we looking at?
+
+$$
+\boldsymbol {\hat{y}} = \boldsymbol{\hat{y}(x)}, \boldsymbol{\hat{y}}: \mathbb{R}^n \rightarrow \mathbb{R}^K, \boldsymbol{x} \mapsto \boldsymbol{\hat{y}}
+$$
+
+However, it is helpful to visualize the fact that there is a hidden layer, and the mapping can be expanded as:
+
+$$
+\boldsymbol{\hat{y}}: \mathbb{R}^{n} \rightarrow \mathbb{R}^d \rightarrow \mathbb{R}^K, d \gg n, K
+$$
+
+What might an example configuration for the case above look like? In this case, one has input of dimension two ($n=2$), the single hidden layer could have dimensionality of 1000 ($d = 1000$), and we have 3 classes ($C=3$). There are good practical reasons to not have so many neurons in one hidden layer, so it could make sense to split that single hidden layer into 3 with 10 neurons each ($1000 \rightarrow 10 \times 10 \times 10$). -->
+
+## Rede neural (inferência)
+
+Vamos pensar sobre a rede neural de três camadas (entrada, oculta, saída) novamente, como vista na **Fig. 6**
+
+<center>
+<img src="{{site.baseurl}}/images/week02/02-3/2-layer-inference.png" height="250px"/><br>
+<b>Fig. 6</b> Rede neural de três camadas
+</center>
+
+Que tipo de funções estamos olhando?
+
+$$
+\boldsymbol {\hat{y}} = \boldsymbol{\hat{y}(x)}, \boldsymbol{\hat{y}}: \mathbb{R}^n \rightarrow \mathbb{R}^K, \boldsymbol{x} \mapsto \boldsymbol{\hat{y}}
+$$
+
+No entanto, é útil visualizar o fato de que há uma camada oculta, e o mapeamento pode ser expandido como:
+
+$$
+\boldsymbol{\hat{y}}: \mathbb{R}^{n} \rightarrow \mathbb{R}^d \rightarrow \mathbb{R}^K, d \gg n, K
+$$
+
+Como seria uma configuração de exemplo para o caso acima? Neste caso, um tem entrada de dimensão dois ($n=2$), a única camada oculta pode ter dimensionalidade de 1000 ($d = 1000$), e temos 3 classes ($C=3$). Existem boas razões práticas para não ter tantos neurônios em uma camada oculta, então pode fazer sentido dividir essa única camada oculta em 3 camadas com 10 neurônios cada ($1000 \rightarrow 10 \times 10 \times 10$).
+
+<!-- ## [Neural network (training I)](https://www.youtube.com/watch?v=WAn6lip5oWk&t=822s)
+
+So what does typical training look like? It is helpful to formulate this into the standard terminology of losses.
+
+First, let us re-introduce the soft (arg)max and explicitly state that it is a common activation function for the last layer, when using negative log-likelihood loss, in cases for multi-class prediction. As stated by Professor LeCun in lecture, this is because you get nicer gradients than if you were to use sigmoids and square loss. In addition, your last layer will already be normalized (the sum of all the neurons in the last layer come out to 1), in a way that is nicer for gradient methods than explicit normalization (dividing by the norm).
+
+The soft (arg)max will give you logits in the last layer that look like this:
+
+$$
+\text{soft{(arg)}max}(\boldsymbol{l})[c] = \frac{ \exp(\boldsymbol{l}[c])}   {\sum^K_{k=1} \exp(\boldsymbol{l}[k])}  \in (0, 1)
+$$
+
+It is important to note that the set is not closed because of the strictly positive nature of the exponential function.
+
+Given the set of the predictions $\matr{\hat{Y}}$, the loss will be:
+
+$$
+\mathcal{L}(\boldsymbol{\hat{Y}}, \boldsymbol{c}) = \frac{1}{m} \sum_{i=1}^m \ell(\boldsymbol{\hat{y}_i}, c_i), \quad
+\ell(\boldsymbol{\hat{y}}, c) = -\log(\boldsymbol{\hat{y}}[c])
+$$
+
+Here $c$ denotes the integer label, not the one hot encoding representation.
+
+So let's do two examples, one where an example is correctly classified, and one where it is not.
+
+Let's say
+
+$$
+\boldsymbol{x}, c = 1 \Rightarrow \boldsymbol{y} =
+{\footnotesize\begin{pmatrix}
+1 \\
+0 \\
+0
+\end{pmatrix}}
+$$
+
+What is the instance wise loss?
+
+For the case of *nearly perfect prediction* ($\sim$ means *circa*):
+
+$$
+\hat{\boldsymbol{y}}(\boldsymbol{x}) =
+{\footnotesize\begin{pmatrix} \sim 1 \\ \sim 0 \\ \sim 0 \end{pmatrix}}
+ \Rightarrow \ell \left(
+{\footnotesize\begin{pmatrix} \sim 1 \\ \sim 0 \\ \sim 0 \end{pmatrix}}
+, 1\right) \rightarrow 0^{+}
+$$
+
+For the case of *nearly absolutely wrong*:
+
+$$ \hat{\boldsymbol{y}}(\boldsymbol{x}) =
+{\footnotesize\begin{pmatrix} \sim 0 \\ \sim 1 \\ \sim 0 \end{pmatrix}}
+\Rightarrow \ell \left(
+{\footnotesize\begin{pmatrix} \sim 0 \\ \sim 1 \\ \sim 0 \end{pmatrix}}
+, 1\right) \rightarrow +\infty  $$
+
+Note in the above examples, $\sim 0 \rightarrow 0^{+}$ and $\sim 1 \rightarrow 1^{-}$. Why is this so? Take a minute to think.
+
+**Note**: It is important to know that if you use `CrossEntropyLoss`, you will get `LogSoftMax` and negative loglikelihood `NLLLoss` bundled together, so don't do it twice! -->
+
+## [Rede neural (treinamento I)](https://www.youtube.com/watch?v=WAn6lip5oWk&t=822s)
+
+Então, como se parece um treinamento típico? É útil formular isso na terminologia padrão de perdas.
+
+Primeiro, vamos reintroduzir a função soft (arg)max e assumir explicitamente que ela é uma função de ativação comum para a última camada quando usamos uma função negativa logarítmica de probabilidade como função de perda *(negative log-likelihood loss)* nos casos de previsão multi classe. Conforme ensinado pelo professor LeCun na palestra, isso ocorre porque você obtém gradientes mais agradáveis do que se você usasse sigmóides e quadráticas como funções de perda. Adicionalmente, sua última camada já estará normalizada (a soma de todos os neurônios na última camada é 1), de uma forma que é melhor para métodos gradientes do que a normalização explícita (dividir pela norma).
+
+A soft (arg)max fornecerá *logits* na última camada que se parecem com isto:
+
+$$
+\text{soft{(arg)}max}(\boldsymbol{l})[c] = \frac{ \exp(\boldsymbol{l}[c])}   {\sum^K_{k=1} \exp(\boldsymbol{l}[k])}  \in (0, 1)
+$$
+
+É importante notar que o conjunto não é fechado devido à natureza estritamente positiva da função exponencial.
+
+Dado o conjunto de previsões $\matr{\hat{Y}}$, a perda será:
+
+$$
+\mathcal{L}(\boldsymbol{\hat{Y}}, \boldsymbol{c}) = \frac{1}{m} \sum_{i=1}^m \ell(\boldsymbol{\hat{y}_i}, c_i), \quad
+\ell(\boldsymbol{\hat{y}}, c) = -\log(\boldsymbol{\hat{y}}[c])
+$$
+
+Aqui $c$ indica o rótulo inteiro, e não sua representação codificada em *one hot*.
+
+Vamos fazer então dois exemplos, um corretamente classificado e outro não.
+
+Digamos
+
+$$
+\boldsymbol{x}, c = 1 \Rightarrow \boldsymbol{y} =
+{\footnotesize\begin{pmatrix}
+1 \\
+0 \\
+0
+\end{pmatrix}}
+$$
+
+Qual é a perda por instância?
+
+Para o caso de um *previsão quase perfeita* ($\sim$ significa *aproximadamente*):
+
+$$
+\hat{\boldsymbol{y}}(\boldsymbol{x}) =
+{\footnotesize\begin{pmatrix} \sim 1 \\ \sim 0 \\ \sim 0 \end{pmatrix}}
+ \Rightarrow \ell \left(
+{\footnotesize\begin{pmatrix} \sim 1 \\ \sim 0 \\ \sim 0 \end{pmatrix}}
+, 1\right) \rightarrow 0^{+}
+$$
+
+Para o caso de uma previsão *quase que absolutamente errada*:
+
+$$ \hat{\boldsymbol{y}}(\boldsymbol{x}) =
+{\footnotesize\begin{pmatrix} \sim 0 \\ \sim 1 \\ \sim 0 \end{pmatrix}}
+\Rightarrow \ell \left(
+{\footnotesize\begin{pmatrix} \sim 0 \\ \sim 1 \\ \sim 0 \end{pmatrix}}
+, 1\right) \rightarrow +\infty  $$
+
+Note que nos exemplos acima, $\sim 0 \rightarrow 0^{+}$ e $\sim 1 \rightarrow 1^{-}$. Porque isto é assim? Tire um minuto para pensar.
+
+**Nota**: É importante saber que se você usar `CrossEntropyLoss`, você vai ter `LogSoftMax` e uma função de probabilidade logaritmica negativa `NLLLoss` empacotadas juntas, então não faça isso duas vezes!
+
+<!-- ## [Neural network (training II)](https://www.youtube.com/watch?v=WAn6lip5oWk&t=2188s)
+
+For training, we aggregate all trainable parameters -- weight matrices and biases -- into a collection we call $\mathbf{\Theta} = \lbrace\boldsymbol{W_h, b_h, W_y, b_y} \rbrace$. This allows us to write the objective function or loss as:
+
+$$
+J \left( \mathbf{\Theta} \right) = \mathcal{L} \left( \boldsymbol{\hat{Y}} \left( \mathbf{\Theta} \right), \boldsymbol c \right) \in \mathbb{R}^{+}
+$$
+
+This makes the loss depend on the output of the network  $\boldsymbol {\hat{Y}} \left( \mathbf{\Theta} \right)$, so we can turn this into an optimization problem.
+
+A simple illustration of how this works can be seen in **Fig. 7**, where $J(\vartheta)$, the function we need to minimise, has only a scalar parameter $\vartheta$.
+
+<center>
+<img src="{{site.baseurl}}/images/week02/02-3/1-GD.png" style="zoom: 60%; background-color:#DCDCDC;" /><br>
+<b>Fig. 7</b> Optimizing a loss function through gradient descent.
+</center>
+
+We pick a random initialization point $\vartheta_0$ -- with associated loss $J(\vartheta_0)$. We can compute the derivative evaluated at that point $J'(\vartheta_0) = \frac{\text{d} J(\vartheta)}{\text{d} \vartheta} (\vartheta_0)$. In this case, the slope of the derivative is positive. So we need to take a step in the direction of steepest descent. In this case, that is $-\frac{\text{d} J(\vartheta)}{\text{d} \vartheta}(\vartheta_0)$.
+
+The iterative repetition of this process is known as gradient descent. Gradient methods are the primary tools to train a neural network.
+
+In order to compute the necessary gradients, we have to use back-propagation
+
+$$ \frac{\partial \, J(\mathbf{\Theta})}{\partial \, \boldsymbol{W_y}} = \frac{\partial \, J(\mathbf{\Theta})}{\partial \, \boldsymbol{\hat{y}}} \; \frac{\partial \, \boldsymbol{\hat{y}}}{\partial \, \boldsymbol{W_y}} \quad \quad \quad  \frac{\partial \, J(\mathbf{\Theta})}{\partial \, \boldsymbol{W_h}} = \frac{\partial \, J(\mathbf{\Theta})}{\partial \, \boldsymbol{\hat{y}}} \; \frac{\partial \, \boldsymbol{\hat{y}}}{\partial \, \boldsymbol h} \;\frac{\partial \, \boldsymbol h}{\partial \, \boldsymbol{W_h}} $$ -->
+
+## [Rede neural (treinamento II)](https://www.youtube.com/watch?v=WAn6lip5oWk&t=2188s)
+
+Para o treinamento, agregamos todos os parâmetros treináveis - matrizes de peso e os vieses -- em uma coleção que chamamos $\mathbf{\Theta} = \lbrace\boldsymbol{W_h, b_h, W_y, b_y} \rbrace$. Isso nos permite escrever a função objetivo ou de perda como:
+
+$$
+J \left( \mathbf{\Theta} \right) = \mathcal{L} \left( \boldsymbol{\hat{Y}} \left( \mathbf{\Theta} \right), \boldsymbol c \right) \in \mathbb{R}^{+}
+$$
+
+Isso faz com que a perda dependa da saída da rede $\boldsymbol {\hat{Y}} \left( \mathbf{\Theta} \right)$, para que possamos transformar isso em um problema de otimização.
+
+Uma ilustração simples de como isso funciona pode ser vista em **Fig. 7**, onde $J(\vartheta)$, a função que precisamos minimizar, tem apenas um parâmetro escalar $\vartheta$.
+
+<center>
+<img src="{{site.baseurl}}/images/week02/02-3/1-GD.png" style="zoom: 60%; background-color:#DCDCDC;" /><br>
+<b>Fig. 7</b> Otimizando uma função de perda através do gradiente descendente.
+</center>
+
+Nós escolhemos um ponto de inicialização aleatório $\vartheta_0$ -- com uma perda associada $J(\vartheta_0)$. Podemos calcular a derivada avaliada naquele ponto $J'(\vartheta_0) = \frac{\text{d} J(\vartheta)}{\text{d} \vartheta} (\vartheta_0)$. Neste caso, a inclinação da derivada é positiva. Portanto, precisamos dar um passo na direção da descida mais íngreme. Neste caso, isso é $-\frac{\text{d} J(\vartheta)}{\text{d} \vartheta}(\vartheta_0)$.
+
+A repetição iterativa desse processo é conhecida como gradiente descendente. Os métodos de gradiente são as principais ferramentas para treinar uma rede neural.
+
+Para calcular os gradientes necessários, temos que usar retropropagação
+
+$$ \frac{\partial \, J(\mathbf{\Theta})}{\partial \, \boldsymbol{W_y}} = \frac{\partial \, J(\mathbf{\Theta})}{\partial \, \boldsymbol{\hat{y}}} \; \frac{\partial \, \boldsymbol{\hat{y}}}{\partial \, \boldsymbol{W_y}} \quad \quad \quad  \frac{\partial \, J(\mathbf{\Theta})}{\partial \, \boldsymbol{W_h}} = \frac{\partial \, J(\mathbf{\Theta})}{\partial \, \boldsymbol{\hat{y}}} \; \frac{\partial \, \boldsymbol{\hat{y}}}{\partial \, \boldsymbol h} \;\frac{\partial \, \boldsymbol h}{\partial \, \boldsymbol{W_h}} $$ 
+
+<!-- ## Spiral classification - Jupyter notebook
+
+The Jupyter notebook can be found [here](https://github.com/Atcold/pytorch-Deep-Learning-Minicourse/blob/master/04-spiral_classification.ipynb). In order to run the notebook, make sure you have `the dl-minicourse` environment installed as specified in [README.md](https://github.com/Atcold/pytorch-Deep-Learning-Minicourse/blob/master/README.md).
+
+An explanation of how to use `torch.device()` can be found in [last week's notes](https://atcold.github.io/pytorch-Deep-Learning-Minicourse/en/week01/01-3/).
+
+Like before, we are going to be working with points in $\mathbb{R}^2$ with three different categorical labels -- in red, yellow and blue -- as can be seen in **Fig. 8**.
+
+<center>
+<img src="{{site.baseurl}}/images/week02/02-3/2-data.png" style="zoom: 50%; background-color:#DCDCDC;" /><br>
+<b>Fig. 8</b> Spiral classification data.
+</center>
+
+`nn.Sequential()` is a container, which passes modules to the constructor in the order that they are added; `nn.linear()` is miss-named as it applies an **affine** transformation to the incoming data: $\boldsymbol y = \boldsymbol W \boldsymbol x + \boldsymbol b$. For more information, refer to the [PyTorch documentation](https://pytorch.org/docs/stable/nn.html).
+
+Remember, an affine transformation is five things: rotation, reflection, translation, scaling and shearing.
+
+As it can be seen in **Fig. 9**, when trying to separate the spiral data with linear decision boundaries - only using `nn.linear()` modules, without a non-linearity between them - the best we can achieve is an accuracy of $50\%$.
+
+<center>
+<img src="{{site.baseurl}}/images/week02/02-3/3-linear.png" style="zoom: 60%; background-color:#DCDCDC;" /><br>
+<b>Fig. 9</b> Linear decision boundaries.
+</center>
+
+When we go from a linear model to one with two `nn.linear()` modules and a `nn.ReLU()` between them, the accuracy goes up to $95\%$. This is because the boundaries become non-linear and adapt much better to the spiral form of the data, as it can be seen in **Fig. 10**.
+
+<center>
+<img src="{{site.baseurl}}/images/week02/02-3/4-non-linear.png" style="zoom: 64%; background-color:#DCDCDC;" /><br>
+    <b>Fig. 10</b> Non-linear decision boundaries.
+</center>
+
+An example of a regression problem which can't be solved correctly with a linear regression, but is easily solved with the same neural network structure can be seen in [this notebook](https://github.com/Atcold/pytorch-Deep-Learning-Minicourse/blob/master/05-regression.ipynb) and **Fig. 11**, which shows 10 different networks, where 5 have a `nn.ReLU()` link function and 5 have a `nn.Tanh()`. The former is a piecewise linear function, whereas the latter is a continuous and smooth regression.
+
+<center>
+<img src="{{site.baseurl}}/images/week02/02-3/5-nn-reg.png" style="zoom: 64%; background-color:#DCDCDC;" /><br>
+<b>Fig. 11</b>: 10 Neural networks, along with their variance and standard deviation.<br>
+Left: Five <code>ReLU</code> networks.  Right: Five <code>tanh</code> networks.
+</center>
+
+The yellow and green lines show the standard deviation and variance for the networks. Using these is useful for something similar to a "confidence interval" -- since the functions give a single prediction per output. Using ensemble variance prediction allows us to estimate the uncertainty with which the prediction is being made. The importance of this can be seen in **Fig. 12**, where we extend the decision functions outside the training interval and these tend towards $+\infty, -\infty$.
+
+<center>
+<img src="{{site.baseurl}}/images/week02/02-3/6-nn-confidence.png" style="zoom: 64%; background-color:#DCDCDC;" /><br>
+<b>Fig. 12</b> Neural networks, with mean and standard deviation, outside training interval.<br>
+Left: Five <code>ReLU</code> networks.  Right: Five <code>tanh</code> networks.
+</center>
+
+To train any Neural Network using PyTorch, you need 5 fundamental steps in the training loop:
+
+1. `output = model(input)` is the model's forward pass, which takes the input and generates the output.
+2. `J = loss(output, target <or> label)` takes the model's output and calculates the training loss with respect to the true target or label.
+3. `model.zero_grad()` cleans up the gradient calculations, so that they are not accumulated for the next pass.
+4. `J.backward()` does back-propagation and accumulation: It computes $\nabla_\texttt{x} J$ for every variable $\texttt{x}$ for which we have specified `requires_grad=True`. These are accumulated into the gradient of each variable: $\texttt{x.grad} \gets \texttt{x.grad} +  \nabla_\texttt{x} J$.
+5. `optimiser.step()` takes a step in gradient descent: $\vartheta \gets \vartheta - \eta\, \nabla_\vartheta J$.
+
+When training a NN, it is very likely that you need these 5 steps in the order they were presented. -->
+
+## Classificação espiral - *Jupyter notebook*
+
+O *Jupyter notebook* pode ser encontrado [aqui](https://github.com/Atcold/pytorch-Deep-Learning-Minicourse/blob/master/04-spiral_classification.ipynb). Para executar o notebook, certifique-se de ter o ambiente do mini curso `the dl-minicourse` instalado como especificado no [README.md](https://github.com/Atcold/pytorch-Deep-Learning-Minicourse/blob/master/README.md).
+
+Uma explicação de como usar `torch.device()` pode ser encontrada nas [notas da semana passada](https://atcold.github.io/pytorch-Deep-Learning-Minicourse/en/week01/01-3/).
+
+Como antes, trabalharemos com pontos em $\mathbb{R}^2$ com três rótulos de categorias diferentes -- em vermelho, amarelo e azul -- como pode ser visto em **Fig. 8**.
+
+<center>
+<img src="{{site.baseurl}}/images/week02/02-3/2-data.png" style="zoom: 50%; background-color:#DCDCDC;" /><br>
+<b>Fig. 8</b> Dados da classificação espiral.
+</center>
+
+`nn.Sequential()` é um contêiner, que passa os módulos para o construtor na ordem em que são adicionados; `nn.linear()` tem um nome incorreto, pois aplica uma transformação **afim** para os dados de entrada: $\boldsymbol y = \boldsymbol W \boldsymbol x + \boldsymbol b$. Para obter mais informações, consulte a [documentação PyTorch](https://pytorch.org/docs/stable/nn.html).
+
+Lembre-se, uma transformação afim consiste em cinco coisas: rotação, reflexão, translação, dimensionamento e cisalhamento.
+
+Como pode ser visto na **Fig. 9**, ao tentar separar os dados espirais com limites de decisão linear - apenas usando módulos `nn.linear()`, sem uma não linearidade entre eles - o melhor que podemos alcançar é uma precisão de $50\%$.
+
+<center>
+<img src="{{site.baseurl}}/images/week02/02-3/3-linear.png" style="zoom: 60%; background-color:#DCDCDC;" /><br>
+<b>Fig. 9</b> Limites de decisão lineares.
+</center>
+
+Quando vamos de um modelo linear para um com dois módulos `nn.linear()` e um `nn.ReLU()` entre eles, a precisão vai até $95\%$. Isso ocorre porque os limites se tornam não lineares e se adaptam muito melhor à forma espiral dos dados, como pode ser visto em **Fig. 10**.
+
+<center>
+<img src="{{site.baseurl}}/images/week02/02-3/4-non-linear.png" style="zoom: 64%; background-color:#DCDCDC;" /><br>
+    <b>Fig. 10</b> Limites de decisão não lineares.
+</center>
+
+Um exemplo de problema de regressão que não pode ser resolvido corretamente com uma regressão linear, mas é facilmente resolvido com a mesma estrutura de rede neural pode ser visto [neste caderno](https://github.com/Atcold/pytorch-Deep-Learning-Minicourse/blob/master/05-regression.ipynb) e na **Fig. 11**, que mostra 10 redes diferentes, onde 5 têm `nn.ReLU()` como função conectora e 5 tem `nn.Tanh()` como conectora. A primeira é uma função linear por partes, enquanto a última é uma regressão contínua e suave.
+
+<center>
+<img src="{{site.baseurl}}/images/week02/02-3/5-nn-reg.png" style="zoom: 64%; background-color:#DCDCDC;" /><br>
+<b>Fig. 11</b>: 10 redes neurais, junto com sua variância e desvio padrão.<br>
+Esquerda: Cinco redes <code>ReLU</code>. Direita: Cinco redes <code>tanh</code>.
+</center>
+
+As linhas amarelas e verdes mostram o desvio padrão e a variância das redes. Usar isso é útil para ter algo semelhante a um "intervalo de confiança" -- uma vez que as funções fornecem uma única previsão por saída. O uso da previsão da variância do conjunto nos permite estimar a incerteza com a qual a previsão está sendo feita. A importância disso pode ser vista na **Fig. 12**, onde estendemos as funções de decisão fora do intervalo de treinamento e estas tendem a $+\infty, -\infty$.
+
+<center>
+<img src="{{site.baseurl}}/images/week02/02-3/6-nn-confidence.png" style="zoom: 64%; background-color:#DCDCDC;" /><br>
+<b>Fig. 12</b> Redes neurais, com média e desvio padrão, fora do intervalo de treinamento.<br>
+Esquerda: Cinco redes <code>ReLU</code>. Direita: Cinco redes <code>tanh</code>.
+</center>
+
+Para treinar qualquer rede neural usando PyTorch, você precisa de 5 etapas fundamentais no loop de treinamento:
+
+1. `output = model(input)` é o passo adiante do modelo, que recebe a entrada e gera a saída.
+2. `J = loss(output, target <or> label)` pega a saída do modelo e calcula a perda do treinamento em relação ao verdadeiro objetivo ou rótulo.
+3. `model.zero_grad()` limpa os cálculos de gradiente, de modo que eles não sejam acumulados para a próxima passagem.
+4. `J.backward()` faz a retropropagação e a acumulação: Calcula $\nabla_\texttt{x} J$ para cada variável $\texttt{x}$ para a qual nós especificamos `requires_grad=True`. E são acumulados no gradiente de cada variável: $\texttt{x.grad} \gets \texttt{x.grad} +  \nabla_\texttt{x} J$.
+5. `optimiser.step()` dá um passo no gradiente descendente: $\vartheta \gets \vartheta - \eta\, \nabla_\vartheta J$.
+
+Ao treinar uma *NN*, é muito provável que você precise dessas 5 etapas na ordem em que foram apresentadas.

--- a/docs/pt/week02/02.md
+++ b/docs/pt/week02/02.md
@@ -1,0 +1,37 @@
+---
+lang: pt
+lang-ref: ch.02
+title: Semana 2
+translation-date: 22 Jan 2021
+translator: Lenin Cristi
+---
+
+<!--
+## Lecture part A
+
+We start by understanding what parametrised models are and then discuss what a loss function is. We then look at Gradient-based methods and how it's used in the backpropagation algorithm in a traditional neural network. We conclude this section by learning how to implement a neural network in PyTorch followed by a discussion on a more generalized form of backpropagation.
+-->
+
+## Curso parte A
+
+Começamos nossa segunda semana entendendo o que são modelos parametrizados e depois discutimos o que é uma função de perda. Em seguida, examinamos os métodos baseados em gradiente e como eles são usados no algoritmo de retropropagação em uma rede neural tradicional. Concluímos esta seção aprendendo como implementar uma rede neural em PyTorch seguido por uma discussão sobre uma forma mais generalizada de retropropagação.
+
+<!--
+## Lecture part B
+
+We begin with a concrete example of backpropagation and discuss the dimensions of Jacobian matrices. We then look at various basic neural net modules and compute their gradients, followed by a brief discussion on softmax and logsoftmax. The other topic of discussion in this part is Practical Tricks for backpropagation.
+-->
+
+## Curso parte B
+
+Iniciamos com um exemplo concreto de retropropagação e discutimos as dimensões das matrizes Jacobianas. Olhamos então para vários módulos básicos de rede neural e calculamos seus gradientes, seguindo com uma breve discussão sobre as funções softmax e logsoftmax. Outro tópico de discussão nesta parte são alguns truques práticos para retropropagação.
+
+<!--
+## Practicum
+
+We give a brief introduction to supervised learning using artificial neural networks. We expound on the problem formulation and conventions of data used to train these networks. We also discuss how to train a neural network for multi class classification, and how to perform inference once the network is trained.
+-->
+
+## Prática
+
+Damos uma breve introdução à aprendizagem de máquina supervisionada usando redes neurais artificiais. Explicamos como melhor formular o problema e as convenções na preparação dos dados usados para treinar essas redes. Também discutimos como treinar uma rede neural para classificação multiclasse e como realizar inferência depois que a rede estiver treinada.


### PR DESCRIPTION
Notes about the translation

I maintained the English blocks in the source as the other versions but sliced them into bigger blocks by topic, I think it facilitates the translation.

I always used the English material as the primary source, in sentences where the translation to Portuguese didn't fully express the final meaning of the source material, I relied on the Spanish version (a version with more contributors and a mature version I think) just for that word to decide to translate or not.

For an example of a not translated term, in the 02-1 after the "Nash Equilibria" the acronym "GAN" (or generative adversarial network) is not translated in Spanish and I didn't translate either, because if you look up this acronym on the Portuguese Google, you will not find the correct explanation about the term, it's not even the same field, in all cases like that, I put the word or acronym in italic (even if it is not in italic on the Spanish translation), so we not got non-translated terms outside italic to easily find and recognize them. Other examples are "RL", "SGD" or "one-hot" which terms are more easily recognizable in Portuguese by the English acronym, but all of them have the Portuguese term right after on parenthesis. The terms softmax and log softmax are exceptions as are many cases in the 02-2 text and are easily recognizable (and used in this form) in Portuguese. The term "Dropout" has no term in Portuguese close or better to the understanding of this meaning (as "drop + out" is common and simple words) and so I maintained the term untouched.

The term "Actor-Critic Methods" was translated in Spanish, but I didn't find much of the "Actor-Critic Methods" translations, except for one academic paper in Portuguese with a similar term for the same technique (https://tedebc.ufma.br/jspui/bitstream/tede/1879/2/Patricia%20Helena.pdf), and so I included this term in the translation, but in parenthesis after the English term. If the reader wants to get deeper into this technique, he will find at least this (or related) academic paper in Portuguese.

As I used the English material as a primary source, there are cases when a term is not translated in Spanish translation but I translated it to Portuguese when the term has a Portuguese mathematical (or universal) recognizable form, the better example is "negative log-likelihood loss" which I understood as a "negative logarithmic probabilistic function used as a loss function" in this case, I translated and included the source English form in the parenthesis.

The term "logits" was not translated either because I found multiple explanations (as in https://stackoverflow.com/questions/41455101/what-is-the-meaning-of-the-word-logits-in-tensorflow) for this term into the same field, and as in the Spanish version I maintained de original term.
