### PR TITLE
in compliance with Torchtext >= 0.9.0

### DIFF
--- a/12-regularization.ipynb
+++ b/12-regularization.ipynb
@@ -37,8 +37,16 @@
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline\n",
     "\n",
+    "# Checnking for module version \n",
+    "from cmp_version import cmp_version \n",
+    "\n",
     "# PyTorch imports\n",
-    "from torchtext import data, datasets\n",
+    "from torchtext import __version__ as ttver\n",
+    "# https://github.com/pytorch/text/releases/tag/v0.9.0-rc5\n",
+    "if cmp_version(ttver,\"0.9.0\")>=0: \n",
+    "    from torchtext.legacy import data, datasets\n",
+    "else:\n",
+    "    from torchtext import data, datasets\n",
     "import torch\n",
     "import torch.nn as nn\n",
     "import torch.nn.functional as F\n",
@@ -633,6 +641,24 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.3"
+  },
+  "latex_envs": {
+   "LaTeX_envs_menu_present": true,
+   "autoclose": false,
+   "autocomplete": true,
+   "bibliofile": "biblio.bib",
+   "cite_by": "apalike",
+   "current_citInitial": 1,
+   "eqLabelWithNumbers": true,
+   "eqNumInitial": 1,
+   "hotkeys": {
+    "equation": "Ctrl-E",
+    "itemize": "Ctrl-I"
+   },
+   "labels_anchors": false,
+   "latex_user_defs": false,
+   "report_style_numbering": false,
+   "user_envs_cfg": false
   }
  },
  "nbformat": 4,

--- a/12-regularization.ipynb
+++ b/12-regularization.ipynb
@@ -641,24 +641,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.3"
-  },
-  "latex_envs": {
-   "LaTeX_envs_menu_present": true,
-   "autoclose": false,
-   "autocomplete": true,
-   "bibliofile": "biblio.bib",
-   "cite_by": "apalike",
-   "current_citInitial": 1,
-   "eqLabelWithNumbers": true,
-   "eqNumInitial": 1,
-   "hotkeys": {
-    "equation": "Ctrl-E",
-    "itemize": "Ctrl-I"
-   },
-   "labels_anchors": false,
-   "latex_user_defs": false,
-   "report_style_numbering": false,
-   "user_envs_cfg": false
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
By TorchText 0.9.0 Release the `torchtext.data.Field` has changed to  `torchtext.legacy.data.Field`.