### PR TITLE
Update 09-echo_data.ipynb

### DIFF
--- a/09-echo_data.ipynb
+++ b/09-echo_data.ipynb
@@ -40,6 +40,7 @@
     "    batch_size=batch_size,\n",
     "    series_length=series_length,\n",
     "    truncated_length=BPTT_T,\n",
+    "    total_values_in_one_chunck = batch_size * BPTT_T,\n",
     ")\n",
     "train_size = len(train_data)\n",
     "\n",
@@ -150,7 +151,8 @@
     "        optimizer.step()\n",
     "        \n",
     "        pred = (torch.sigmoid(logits) > 0.5)\n",
-    "        correct += (pred == target.byte()).int().sum().item()\n",
+    "        correct += (pred == target.byte()).int().sum().item()/total_values_in_one_chunck\n",
+
     "        \n",
     "    return correct, loss.item(), hidden"
    ]
@@ -171,7 +173,7 @@
     "            logits, hidden = model(data, hidden)\n",
     "            \n",
     "            pred = (torch.sigmoid(logits) > 0.5)\n",
-    "            correct += (pred == target.byte()).int().sum().item()\n",
+    "        correct += (pred == target.byte()).int().sum().item()/total_values_in_one_chunck\n",
     "\n",
     "    return correct"
    ]
@@ -208,7 +210,7 @@
     "while epoch < n_epochs:\n",
     "    correct, loss, hidden = train(hidden)\n",
     "    epoch += 1\n",
-    "    train_accuracy = float(correct) / train_size\n",
+    "    train_accuracy = float(correct)*100/ train_size\n",
     "    print(f'Train Epoch: {epoch}/{n_epochs}, loss: {loss:.3f}, accuracy {train_accuracy:.1f}%')\n",
     "\n",
     "#test    \n",


### PR DESCRIPTION
Hi Alfredo,

I realized that when we increase the batch_size = 5 to batch_size = 100, the accuracy goes above 100%. I proposed the following changes to correct it:


Change 1: 

Added one constant: 
total_values_in_one_chunck = batch_size * BPTT_T


Change 2:


Changed:
correct += (pred == target.byte()).int().sum().item()

To (in both def train(hidden) and def test(hidden)):
correct += (pred == target.byte()).int().sum().item()/total_values_in_one_chunck

(After this change, we get a number between 0 and 1 for each comparison,  to be added to the previous correct value, instead of a number between 0 and otal_values_in_one_chunck  (batch_size * BPTT_T)


Change 3:

Changed:
train_accuracy = float(correct) / train_size # train_size = num_of_chuncks

To:
train_accuracy = float(correct)*100 / train_size # train_size = num_of_chuncks

After these 3 changes, we get accuracy below 100 % for batch_size = 100 and above because what is now being added to the "correct" after each comparison is a percentage (between 0 and 1), which makes more sense to me to evaluate the equality rate of two vectors rather than total number of equal values.

Please let me know what you think. 

Thanks,
Gelareh