### PR TITLE
[JA] fix-week-05-1

### DIFF
--- a/docs/ja/week05/05-1.md
+++ b/docs/ja/week05/05-1.md
@@ -47,7 +47,7 @@ $$
 
 ここでの前提は、関数$f$が連続的で微分可能であることです。
 目的は、最適化関数の最低点（谷）を見つけることです。 ただし、この谷への実際の方向は不明です。
-局所的に探ることしかできないため、負の勾配が手に入る最適な情報です。
+局所的に探ることしかできないため、負の勾配が私達が手に入れられる最適な情報です。
 その方向に小さいステップサイズで進んで、近づいていくだけです。 小さな一歩を踏み出してから、再び新しい勾配を計算し、谷に到達するまでその方向に少しだけ移動します。 すると、本質的に勾配降下法が行っているのは、最も急な降下（負の勾配）の方向に向かうことだけです。
 
 
@@ -68,8 +68,8 @@ $$
 
 <center>
 <img src="{{site.baseurl}}/images/week05/05-1/step-size.png" style="zoom: 70%; background-color:#DCDCDC;" /><br>
-<!-- <b><!-- Figure 1:</b> Step sizes for 1D Quadratic -->
-<b><!-- 図１:</b> 1D 2次公式でのステップサイズ
+<!-- <b>Figure 1:</b> Step sizes for 1D Quadratic -->
+<b>図１:</b> 1次元の2次関数に対するステップサイズ
 </center>
 
 
@@ -245,7 +245,7 @@ $$
 ネステロフのモメンタムは，定数を慎重に選択すると、収束を加速できます。 ただし、これは凸最適化問題にのみ適用され、ニューラルネットワークには適用されません。
 
 <!-- Many people say that normal momentum is also an accelerated method. But in reality, it is accelerated only for quadratics. Also, acceleration does not work well with SGD, as SGD has noise and acceleration does not work well with noise. Therefore, though some bit of acceleration is present with Momentum SGD, it alone is not a good explanation for the high performance of the technique. -->
-通常のモメンタムも加速された方法と言われていますが、実際には、二次方程式に対して加速されるのみです。 また、SGDにはノイズがあり、加速はノイズではうまく機能しないため、加速はSGDではうまく機能しません。 したがって、モメンタムSGDには多少の加速がありますが、それだけでは、この手法の高性能を説明するのに適していません。
+通常のモメンタムも加速された方法と言われていますが、実際には、二次関数に対して加速されるのみです。 また、SGDにはノイズがあり、加速はノイズではうまく機能しないため、加速はSGDではうまく機能しません。 したがって、モメンタムSGDには多少の加速がありますが、それだけでは、この手法の高性能を説明するのに適していません。
 
 
 <!-- #### Noise smoothing
@@ -266,14 +266,15 @@ $$
 $$
 
 <!-- The great thing about SGD with momentum is that this averaging is no longer necessary. Momentum adds smoothing to the optimization process, which makes each update a good approximation to the solution. With SGD you would want to average a whole bunch of updates and then take a step in that direction.　-->
-モメンタムのあるSGDの優れている点は、この平均化が不要になったことです。 モメンタムは、最適化プロセスに平滑化を追加します。これにより、各更新が解の適切な近似になります。 SGDを使用すると、一連の更新を平均して、その方向に一歩踏み出すことができます。
+モメンタムを用いたSGDの優れている点は、この平均化が不要になったことです。 モメンタムは、最適化プロセスに平滑化を追加します。これにより、各更新が解の適切な近似になります。 SGDを使用すると、一連の更新を平均して、その方向に一歩踏み出すことができます。
 
-<!-- Both Acceleration and Noise smoothing contribute to high performance of momentum.
-加速とノイズ平滑化の両方が運動量の高性能に役に立ちます。
+<!-- Both Acceleration and Noise smoothing contribute to high performance of momentum.　-->
+加速とノイズ平滑化のおかげでモメンタムは高性能になっています。
 
 <center>
 <img src="{{site.baseurl}}/images/week05/05-1/sgd-vs-momentum.png" style="zoom: 35%; background-color:#DCDCDC;"/><br>
 <b>Figure 5:</b> SGD <i>vs.</i> Momentum
 </center>
 
-<!-- With SGD, we make good progress towards solution initially but when we reach bowl (bottom of the valley) we bounce around in this floor. If we adjust learning rate we will bounce around slower. With momentum we smooth out the steps, so that there is no bouncing around.
+<!-- With SGD, we make good progress towards solution initially but when we reach bowl (bottom of the valley) we bounce around in this floor. If we adjust learning rate we will bounce around slower. With momentum we smooth out the steps, so that there is no bouncing around. -->
+SGDの場合、最初は解に向かって順調に進むのですが、ボウル（谷底）に到達すると、この床を跳ね回るようになります。学習率を調整すれば、跳ね回る速度は遅くすることができます。モメンタムを使えば、ステップを滑らかにすることで、跳ね回り自体をなくすことができます。


### PR DESCRIPTION
https://atcold.github.io/pytorch-Deep-Learning/ja/week05/05-1/

The closing bold tag (`</b>`) at caption of figure 1 is commented out, so all following elements are children of that. Because of this, markdown is not working.