### PR TITLE
added keras-style model summaries for torch models and colormap to view MNIST images in greyscale

### DIFF
--- a/06-convnet.ipynb
+++ b/06-convnet.ipynb
@@ -56,15 +56,17 @@
     "import torch.nn.functional as F\n",
     "import torch.optim as optim\n",
     "from torchvision import datasets, transforms\n",
+    "from torchinfo import summary\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy\n",
+    "\n",
     "\n",
     "# function to count number of parameters\n",
     "def get_n_params(model):\n",
     "    np=0\n",
     "    for p in list(model.parameters()):\n",
     "        np += p.nelement()\n",
-    "    return np"
+    "    return np    "
    ]
   },
   {
@@ -122,7 +124,8 @@
     "for i in range(10):\n",
     "    plt.subplot(2, 5, i + 1)\n",
     "    image, _ = train_loader.dataset.__getitem__(i)\n",
-    "    plt.imshow(image.squeeze().numpy())\n",
+    "    plt.imshow(image.squeeze().numpy(), cmap='gray')\n",
+    "    \n",
     "    plt.axis('off');"
    ]
   },
@@ -261,7 +264,9 @@
     "model_fnn = FC2Layer(input_size, n_hidden, output_size)\n",
     "model_fnn.to(device)\n",
     "optimizer = optim.SGD(model_fnn.parameters(), lr=0.01, momentum=0.5)\n",
-    "print('Number of parameters: {}'.format(get_n_params(model_fnn)))\n",
+    "\n",
+    "print(summary(model_fnn, input_shape=(1, 1, 28, 28)), '\\n')\n",
+    "# print('Number of parameters: {}'.format(get_n_params(model_fnn)))\n",
     "\n",
     "for epoch in range(0, 1):\n",
     "    train(epoch, model_fnn)\n",
@@ -287,7 +292,9 @@
     "model_cnn = CNN(input_size, n_features, output_size)\n",
     "model_cnn.to(device)\n",
     "optimizer = optim.SGD(model_cnn.parameters(), lr=0.01, momentum=0.5)\n",
-    "print('Number of parameters: {}'.format(get_n_params(model_cnn)))\n",
+    "\n",
+    "print(summary(model_cnn, input_shape=(1, 1, 28, 28)), '\\n')\n",
+    "# print('Number of parameters: {}'.format(get_n_params(model_cnn)))\n",
     "\n",
     "for epoch in range(0, 1):\n",
     "    train(epoch, model_cnn)\n",
@@ -321,10 +328,10 @@
     "    image_perm = image_perm[:, perm]\n",
     "    image_perm = image_perm.view(-1, 1, 28, 28)\n",
     "    plt.subplot(4, 5, i + 1)\n",
-    "    plt.imshow(image.squeeze().numpy())\n",
+    "    plt.imshow(image.squeeze().numpy(), cmap='gray')\n",
     "    plt.axis('off')\n",
     "    plt.subplot(4, 5, i + 11)\n",
-    "    plt.imshow(image_perm.squeeze().numpy())\n",
+    "    plt.imshow(image_perm.squeeze().numpy(), cmap='gray')\n",
     "    plt.axis('off')"
    ]
   },
@@ -436,9 +443,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:dl-minicourse] *",
+   "display_name": "conda_py3",
    "language": "python",
-   "name": "conda-env-dl-minicourse-py"
+   "name": "conda_py3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -450,7 +457,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
1. Added keras-style model summaries for torch models to view model graphs along with number of trainable params per layer (needs new package [torchinfo](https://github.com/TylerYep/torchinfo)
2. Added [color map](https://matplotlib.org/stable/tutorials/introductory/images.html) when plotting images in matplotlib to view MNIST images in greyscale