### PR TITLE
Fixed the hinge loss equation

### DIFF
--- a/docs/bn/week11/11-2.md
+++ b/docs/bn/week11/11-2.md
@@ -324,7 +324,7 @@ $$
 ### হিঞ্জ লস
 
 $$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
+L_{\text{hinge}}(W,Y^i,X^i)=( m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )^+
 $$
 
 <!-- Where $\bar Y^i$ is the *most offending incorrect answer*. This loss enforces that the difference between the correct answer and the most offending incorrect answer be at least $m$. -->

--- a/docs/bn/week11/11-2.md
+++ b/docs/bn/week11/11-2.md
@@ -324,7 +324,7 @@ $$
 ### হিঞ্জ লস
 
 $$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0,m+E(W,Y^i,X^i))-E(W,\bar Y^i,X^i)
+L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
 $$
 
 <!-- Where $\bar Y^i$ is the *most offending incorrect answer*. This loss enforces that the difference between the correct answer and the most offending incorrect answer be at least $m$. -->

--- a/docs/en/week11/11-2.md
+++ b/docs/en/week11/11-2.md
@@ -238,7 +238,7 @@ If the energy function is able to ensure that the energy of the *most offending 
 ### Hinge Loss
 
 $$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0,m+E(W,Y^i,X^i))-E(W,\bar Y^i,X^i)
+L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
 $$
 
 Where $\bar Y^i$ is the *most offending incorrect answer*. This loss enforces that the difference between the correct answer and the most offending incorrect answer be at least $m$.

--- a/docs/en/week11/11-2.md
+++ b/docs/en/week11/11-2.md
@@ -238,7 +238,7 @@ If the energy function is able to ensure that the energy of the *most offending 
 ### Hinge Loss
 
 $$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
+L_{\text{hinge}}(W,Y^i,X^i)=( m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )^+
 $$
 
 Where $\bar Y^i$ is the *most offending incorrect answer*. This loss enforces that the difference between the correct answer and the most offending incorrect answer be at least $m$.

--- a/docs/es/week11/11-2.md
+++ b/docs/es/week11/11-2.md
@@ -546,12 +546,12 @@ Si la función de energía es capaz de asegurar que la energía de la *respuesta
 ### Pérdida de Bisagra
 
 <!--$$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0,m+E(W,Y^i,X^i))-E(W,\bar Y^i,X^i)
+L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
 $$
 -->
 
 $$
-L_{\text{bisagra}}(W,Y^i,X^i)=\max(0,m+E(W,Y^i,X^i))-E(W,\bar Y^i,X^i)
+L_{\text{bisagra}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
 $$
 
 <!--Where $\bar Y^i$ is the *most offending incorrect answer*. This loss enforces that the difference between the correct answer and the most offending incorrect answer be at least $m$.

--- a/docs/es/week11/11-2.md
+++ b/docs/es/week11/11-2.md
@@ -546,12 +546,12 @@ Si la función de energía es capaz de asegurar que la energía de la *respuesta
 ### Pérdida de Bisagra
 
 <!--$$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
+L_{\text{hinge}}(W,Y^i,X^i)=( m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )^+
 $$
 -->
 
 $$
-L_{\text{bisagra}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
+L_{\text{bisagra}}(W,Y^i,X^i)=( m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )^+
 $$
 
 <!--Where $\bar Y^i$ is the *most offending incorrect answer*. This loss enforces that the difference between the correct answer and the most offending incorrect answer be at least $m$.

--- a/docs/fr/week11/11-2.md
+++ b/docs/fr/week11/11-2.md
@@ -479,7 +479,7 @@ Si la fonction d'énergie est capable de garantir que l'énergie de la *réponse
 ### Hinge Loss
 
 $$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0,m+E(W,Y^i,X^i))-E(W,\bar Y^i,X^i)
+L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
 $$
 
 Where $\bar Y^i$ is the *most offending incorrect answer*. This loss enforces that the difference between the correct answer and the most offending incorrect answer be at least $m$.
@@ -497,7 +497,7 @@ A: It's arbitrary, but it affects the weights of the last layer.
 ### Perte *Hinge*
 
 $$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0,m+E(W,Y^i,X^i))-E(W,\bar Y^i,X^i)
+L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
 $$
 
 où $\bar Y^i$ est la *réponse incorrecte la plus offensante*. Cette perte impose que la différence entre la bonne réponse et la réponse incorrecte la plus offensante soit d'au moins $m$.

--- a/docs/fr/week11/11-2.md
+++ b/docs/fr/week11/11-2.md
@@ -479,7 +479,7 @@ Si la fonction d'énergie est capable de garantir que l'énergie de la *réponse
 ### Hinge Loss
 
 $$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
+L_{\text{hinge}}(W,Y^i,X^i)=( m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )^+
 $$
 
 Where $\bar Y^i$ is the *most offending incorrect answer*. This loss enforces that the difference between the correct answer and the most offending incorrect answer be at least $m$.
@@ -497,7 +497,7 @@ A: It's arbitrary, but it affects the weights of the last layer.
 ### Perte *Hinge*
 
 $$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
+L_{\text{hinge}}(W,Y^i,X^i)=( m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )^+
 $$
 
 où $\bar Y^i$ est la *réponse incorrecte la plus offensante*. Cette perte impose que la différence entre la bonne réponse et la réponse incorrecte la plus offensante soit d'au moins $m$.

--- a/docs/it/week11/11-2.md
+++ b/docs/it/week11/11-2.md
@@ -441,7 +441,7 @@ If the energy function is able to ensure that the energy of the *most offending 
 ### Perdita _hinge_
 
 $$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0,m+E(W,Y^i,X^i))-E(W,\bar Y^i,X^i)
+L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
 $$
 
 Dove $\bar Y^i$ è l'"errore più grave". Questa perdita fa sí che la differenza fra l'output giusto e l'errore più grave sia come minimo uguale a $m$.
@@ -449,7 +449,7 @@ Dove $\bar Y^i$ è l'"errore più grave". Questa perdita fa sí che la differenz
 <!-- ### Hinge Loss -->
 
 <!-- $$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0,m+E(W,Y^i,X^i))-E(W,\bar Y^i,X^i)
+L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
 $$
 
 Where $\bar Y^i$ is the *most offending incorrect answer*. This loss enforces that the difference between the correct answer and the most offending incorrect answer be at least $m$. -->

--- a/docs/it/week11/11-2.md
+++ b/docs/it/week11/11-2.md
@@ -441,7 +441,7 @@ If the energy function is able to ensure that the energy of the *most offending 
 ### Perdita _hinge_
 
 $$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
+L_{\text{hinge}}(W,Y^i,X^i)=( m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )^+
 $$
 
 Dove $\bar Y^i$ è l'"errore più grave". Questa perdita fa sí che la differenza fra l'output giusto e l'errore più grave sia come minimo uguale a $m$.
@@ -449,7 +449,7 @@ Dove $\bar Y^i$ è l'"errore più grave". Questa perdita fa sí che la differenz
 <!-- ### Hinge Loss -->
 
 <!-- $$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
+L_{\text{hinge}}(W,Y^i,X^i)=( m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )^+
 $$
 
 Where $\bar Y^i$ is the *most offending incorrect answer*. This loss enforces that the difference between the correct answer and the most offending incorrect answer be at least $m$. -->

--- a/docs/ja/week11/11-2.md
+++ b/docs/ja/week11/11-2.md
@@ -329,7 +329,7 @@ If the energy function is able to ensure that the energy of the *most offending 
 ### ヒンジ損失
 
 $$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0,m+E(W,Y^i,X^i))-E(W,\bar Y^i,X^i)
+L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
 $$
 <!--
 Where $\bar Y^i$ is the *most offending incorrect answer*. This loss enforces that the difference between the correct answer and the most offending incorrect answer be at least $m$. -->

--- a/docs/ja/week11/11-2.md
+++ b/docs/ja/week11/11-2.md
@@ -329,7 +329,7 @@ If the energy function is able to ensure that the energy of the *most offending 
 ### ヒンジ損失
 
 $$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
+L_{\text{hinge}}(W,Y^i,X^i)=( m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )^+
 $$
 <!--
 Where $\bar Y^i$ is the *most offending incorrect answer*. This loss enforces that the difference between the correct answer and the most offending incorrect answer be at least $m$. -->

--- a/docs/ko/week11/11-2.md
+++ b/docs/ko/week11/11-2.md
@@ -353,7 +353,7 @@ $$
 ### 힌지 손실
 
 $$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0,m+E(W,Y^i,X^i))-E(W,\bar Y^i,X^i)
+L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
 $$
 
 <!--Where $\bar Y^i$ is the *most offending incorrect answer*. This loss enforces that the difference between the correct answer and the most offending incorrect answer be at least $m$.-->

--- a/docs/ko/week11/11-2.md
+++ b/docs/ko/week11/11-2.md
@@ -353,7 +353,7 @@ $$
 ### 힌지 손실
 
 $$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
+L_{\text{hinge}}(W,Y^i,X^i)=( m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )^+
 $$
 
 <!--Where $\bar Y^i$ is the *most offending incorrect answer*. This loss enforces that the difference between the correct answer and the most offending incorrect answer be at least $m$.-->

--- a/docs/tr/week11/11-2.md
+++ b/docs/tr/week11/11-2.md
@@ -423,7 +423,7 @@ Enerji fonksiyonu *en rahatsız edici yanlış cevabın* enerjisinin doğru ceva
 <!--### Hinge Loss
 
 $$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0,m+E(W,Y^i,X^i))-E(W,\bar Y^i,X^i)
+L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
 $$
 
 Where $\bar Y^i$ is the *most offending incorrect answer*. This loss enforces that the difference between the correct answer and the most offending incorrect answer be at least $m$.
@@ -439,7 +439,7 @@ A: It's arbitrary, but it affects the weights of the last layer.-->
 ### Hinge Kayıp Terimi
 
 $$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0,m+E(W,Y^i,X^i))-E(W,\bar Y^i,X^i)
+L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
 $$
 
 $\bar Y^i$ *en rahatsız edici yanlış cevap* tır. Bu kayıp, doğru cevap ile en rahatsız edici yanlış cevap arasındaki farkın en az $m$ olmasını zorlar.

--- a/docs/tr/week11/11-2.md
+++ b/docs/tr/week11/11-2.md
@@ -423,7 +423,7 @@ Enerji fonksiyonu *en rahatsız edici yanlış cevabın* enerjisinin doğru ceva
 <!--### Hinge Loss
 
 $$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
+L_{\text{hinge}}(W,Y^i,X^i)=( m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )^+
 $$
 
 Where $\bar Y^i$ is the *most offending incorrect answer*. This loss enforces that the difference between the correct answer and the most offending incorrect answer be at least $m$.
@@ -439,7 +439,7 @@ A: It's arbitrary, but it affects the weights of the last layer.-->
 ### Hinge Kayıp Terimi
 
 $$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
+L_{\text{hinge}}(W,Y^i,X^i)=( m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )^+
 $$
 
 $\bar Y^i$ *en rahatsız edici yanlış cevap* tır. Bu kayıp, doğru cevap ile en rahatsız edici yanlış cevap arasındaki farkın en az $m$ olmasını zorlar.

--- a/docs/zh/week11/11-2.md
+++ b/docs/zh/week11/11-2.md
@@ -385,7 +385,7 @@ If the energy function is able to ensure that the energy of the *most offending 
 ### Hinge Loss
 
 $$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
+L_{\text{hinge}}(W,Y^i,X^i)=( m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )^+
 $$
 
 Where $\bar Y^i$ is the *most offending incorrect answer*. This loss enforces that the difference between the correct answer and the most offending incorrect answer be at least $m$.
@@ -405,7 +405,7 @@ A: It's arbitrary, but it affects the weights of the last layer.
 ### 合页损失 (Hinge Loss)
 
 $$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
+L_{\text{hinge}}(W,Y^i,X^i)=( m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )^+
 $$
 
 Where $\bar Y^i$ is the *most offending incorrect answer*. This loss enforces that the difference between the correct answer and the most offending incorrect answer be at least $m$.

--- a/docs/zh/week11/11-2.md
+++ b/docs/zh/week11/11-2.md
@@ -385,7 +385,7 @@ If the energy function is able to ensure that the energy of the *most offending 
 ### Hinge Loss
 
 $$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0,m+E(W,Y^i,X^i))-E(W,\bar Y^i,X^i)
+L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
 $$
 
 Where $\bar Y^i$ is the *most offending incorrect answer*. This loss enforces that the difference between the correct answer and the most offending incorrect answer be at least $m$.
@@ -405,7 +405,7 @@ A: It's arbitrary, but it affects the weights of the last layer.
 ### 合页损失 (Hinge Loss)
 
 $$
-L_{\text{hinge}}(W,Y^i,X^i)=\max(0,m+E(W,Y^i,X^i))-E(W,\bar Y^i,X^i)
+L_{\text{hinge}}(W,Y^i,X^i)=\max(0, m + E(W,Y^i,X^i) - E(W,\bar Y^i,X^i) )
 $$
 
 Where $\bar Y^i$ is the *most offending incorrect answer*. This loss enforces that the difference between the correct answer and the most offending incorrect answer be at least $m$.


### PR DESCRIPTION
Fixed a small mistake in the hinge loss equation in 11-2 -- the subtraction of the offending example's energy was outside of the max operator, where it should be inside -- see the table provided later in 11.2, or slide 19 here: https://cs.nyu.edu/~yann/talks/lecun-20041200-ebm-whistler.pdf